### PR TITLE
Add line numbers to logging messages and add EVENT log type

### DIFF
--- a/ASF/config/FreeRTOSConfig.h
+++ b/ASF/config/FreeRTOSConfig.h
@@ -18,6 +18,7 @@ void assert_triggered(const char *file, uint32_t line);
 #include <peripheral_clk_config.h>
 
 #define configSUPPORT_STATIC_ALLOCATION 1
+#define INCLUDE_xQueueGetMutexHolder 1
 
 #ifndef configCPU_CLOCK_HZ
 #define configCPU_CLOCK_HZ (CONF_CPU_FREQUENCY)

--- a/ASF/gcc/Makefile
+++ b/ASF/gcc/Makefile
@@ -285,7 +285,7 @@ $(OUTPUT_FILE_PATH): $(OBJS)
 %.o: %.c
 	@echo Building file: $<
 	@echo ARM/GNU C Compiler
-	$(QUOTE)arm-none-eabi-gcc$(QUOTE) -x c -mthumb $(CFLAGS) -Os -ffunction-sections -mlong-calls -g3 -Wall -c -std=gnu99 \
+	$(QUOTE)arm-none-eabi-gcc$(QUOTE) -x c -mthumb $(CFLAGS) -D__FILENAME__=\"$(notdir $<)\" -Os -ffunction-sections -mlong-calls -g3 -Wall -c -std=gnu99 \
 -D__SAMD51P20A__ -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 \
 $(DIR_INCLUDES) \
 -MD -MP -MF "$(patsubst ../%,%, $(@:%.o=%.d))" -MT"$(patsubst ../%,%, $(@:%.o=%.d))" -MT"$(patsubst ../%,%, $(@:%.o=%.o))"  -o "$(strip $(patsubst ../%, %, $@))" "$<"
@@ -294,7 +294,7 @@ $(DIR_INCLUDES) \
 %.o: %.s
 	@echo Building file: $<
 	@echo ARM/GNU Assembler
-	$(QUOTE)arm-none-eabi-as$(QUOTE) -x c -mthumb $(CFLAGS) -Os -ffunction-sections -mlong-calls -g3 -Wall -c -std=gnu99 \
+	$(QUOTE)arm-none-eabi-as$(QUOTE) -x c -mthumb $(CFLAGS) -D__FILENAME__=\"$(notdir $<)\" -Os -ffunction-sections -mlong-calls -g3 -Wall -c -std=gnu99 \
 -D__SAMD51P20A__ -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 \
 $(DIR_INCLUDES) \
 -MD -MP -MF "$(patsubst ../%,%, $(@:%.o=%.d))" -MT"$(patsubst ../%,%, $(@:%.o=%.d))" -MT"$(patsubst ../%,%, $(@:%.o=%.o))"  -o "$(strip $(patsubst ../%, %, $@))" "$<"
@@ -303,7 +303,7 @@ $(DIR_INCLUDES) \
 %.o: %.S
 	@echo Building file: $<
 	@echo ARM/GNU Preprocessing Assembler
-	$(QUOTE)arm-none-eabi-gcc$(QUOTE) -x c -mthumb $(CFLAGS) -Os -ffunction-sections -mlong-calls -g3 -Wall -c -std=gnu99 \
+	$(QUOTE)arm-none-eabi-gcc$(QUOTE) -x c -mthumb $(CFLAGS) -D__FILENAME__=\"$(notdir $<)\" -Os -ffunction-sections -mlong-calls -g3 -Wall -c -std=gnu99 \
 -D__SAMD51P20A__ -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 \
 $(DIR_INCLUDES) \
 -MD -MP -MF "$(patsubst ../%,%, $(@:%.o=%.d))" -MT"$(patsubst ../%,%, $(@:%.o=%.d))" -MT"$(patsubst ../%,%, $(@:%.o=%.o))"  -o "$(strip $(patsubst ../%, %, $@))" "$<"

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ CFLAGS += -Wextra -Werror -Werror=maybe-uninitialized
 CFLAGS += -Wshadow -Wnull-dereference -Wduplicated-cond -Wlogical-op -Werror=return-type -Wfloat-equal
 CFLAGS += -Wdangling-else -Wtautological-compare
 CFLAGS += -fwrapv # Enable fwrapv (wrap on overflow of signed integers) just to be safe
+CFLAGS += -fsigned-char # Ensure that char is signed as your average c programmer might expect -- it's actually default unsigned on arm!
 
 # Disable warnings for unused parameters due to ASF functions having unused parameters
 CFLAGS += -Wno-unused-parameter #Because some ASF functions have unused parameters, supress this warning
@@ -195,14 +196,14 @@ update_asf:
 	&& echo "(6.3) ASF Makefile: GCC output filepaths corrected" \
 	&& $(SED) -i '/main/d' ./ASF/gcc/Makefile \
 	&& echo "(6.4) ASF Makefile: References to ASF main.c removed" \
-	&& $(SED) -i 's/-DDEBUG/$$(CFLAGS)/g' ./ASF/gcc/Makefile \
-	&& echo "(6.5) ASF Makefile: CFLAGS hook injected" \
+	&& $(SED) -i 's/-DDEBUG/$$(CFLAGS) -D__FILENAME__=\\"$$\(notdir $$<)\\"/g' ./ASF/gcc/Makefile \
+	&& echo "(6.5) ASF Makefile: CFLAGS and __FILENAME__ hook injected" \
 	&& $(SED) -i 's/AtmelStart/PVDXos/g' ./ASF/gcc/Makefile \
 	&& echo "(6.6) ASF Makefile: Project name updated to PVDXos" \
 	&& rm -f ./ASF/main.c \
 	&& echo "(7) ASF main.c removed" \
-	&& $(SED) -i 's|// <h> Basic|#define configSUPPORT_STATIC_ALLOCATION 1|' ./ASF/config/FreeRTOSConfig.h \
-	&& echo "(8.1) ASF FreeRTOSConfig.h: Static allocation enabled" \
+	&& $(SED) -i 's|// <h> Basic|#define configSUPPORT_STATIC_ALLOCATION 1\n#define INCLUDE_xQueueGetMutexHolder 1|' ./ASF/config/FreeRTOSConfig.h \
+	&& echo "(8.1) ASF FreeRTOSConfig.h: Static allocation & QueueGetMutexHolder enabled" \
 	&& $(SED) -i 's|#define INCLUDE_uxTaskGetStackHighWaterMark 0|#define INCLUDE_uxTaskGetStackHighWaterMark 1|' ./ASF/config/FreeRTOSConfig.h \
 	&& echo "(8.2) ASF FreeRTOSConfig.h: Task stack high watermark function enabled" \
 	&& $(SED) -i 's|#define configCHECK_FOR_STACK_OVERFLOW 1|#define configCHECK_FOR_STACK_OVERFLOW 2|' ./ASF/config/FreeRTOSConfig.h \
@@ -212,6 +213,3 @@ update_asf:
 	&& find ./ASF -type f -newermt now -exec touch {} + \
 	&& echo "(10) Timestamps in future updated to present" \
 	&& echo " --- Finished Integrating ASF --- "
-
-
-

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,6 +1,16 @@
 #ifndef GLOBALS_H
 #define GLOBALS_H
 
+/* --------- HIGH-LEVEL CONFIG VARIABLES AND DEFINES --------- */
+
+#if defined(RELEASE)
+    #define DEFAULT_LOG_LEVEL INFO // The default log level for the system on release builds
+#else
+    #define DEFAULT_LOG_LEVEL DEBUG // The default log level for the system for debug and unit test builds
+#endif
+
+/* ----------------------------------------------------------- */
+
 #define TASK_STACK_OVERFLOW_PADDING 16 // Buffer for the stack size so that overflow doesn't corrupt any TCBs
 
 #define NUM_TASKS 2 // The number of tasks that the watchdog will check in with
@@ -17,5 +27,13 @@ typedef enum {
     ERROR_UNRECOVERABLE, // If this is returned, the system should restart.
     ERROR_INTERNAL,
 } status_t;
+
+typedef enum {
+    DEBUG = 0,
+    INFO,
+    EVENT,
+    WARNING,
+    FATAL,
+} log_level_t;
 
 #endif // GLOBALS_H

--- a/src/main.c
+++ b/src/main.c
@@ -5,21 +5,22 @@ cosmicmonkeyTaskArguments_t cm_args = {0};
 int main(void) {
     /* Initializes MCU, drivers and middleware */
     atmel_start_init();
-    info("--- ATMEL Initialization Complete ---\n");
-    info("[+] Build Type: %s\n", BUILD_TYPE);
-    info("[+] Build Date: %s\n", BUILD_DATE);
-    info("[+] Build Time: %s\n", BUILD_TIME);
-    info("[+] Built from branch: %s\n", GIT_BRANCH_NAME);
-    info("[+] Built from commit: %s\n", GIT_COMMIT_HASH);
+    // Using the impl version of these functions to avoid cluttering up w/ file and line numbers
+    info_impl("--- ATMEL Initialization Complete ---\n");
+    info_impl("[+] Build Type: %s\n", BUILD_TYPE);
+    info_impl("[+] Build Date: %s\n", BUILD_DATE);
+    info_impl("[+] Build Time: %s\n", BUILD_TIME);
+    info_impl("[+] Built from branch: %s\n", GIT_BRANCH_NAME);
+    info_impl("[+] Built from commit: %s\n", GIT_COMMIT_HASH);
 
     // Bootloader sets a magic number in backup RAM to indicate that it has run successfully
     uint32_t *p_magic_number = (uint32_t *)BOOTLOADER_MAGIC_NUMBER_ADDRESS;
     uint32_t magic_number = *p_magic_number;
     *p_magic_number = 0; // Clear the magic number so that this value doesn't linger
     if (magic_number == BOOTLOADER_MAGIC_NUMBER_VALUE) {
-        info("[+] Bootloader executed normally\n");
+        info_impl("[+] Bootloader executed normally\n");
     } else {
-        warning("[!] Abnormal bootloader behavior (Magic Number: %x)\n", magic_number);
+        warning_impl("[!] Abnormal bootloader behavior (Magic Number: %x)\n", magic_number);
     }
 
     // Initialize the watchdog as early as possible to ensure that the system is reset if the initialization hangs

--- a/src/misc/logging/logging.c
+++ b/src/misc/logging/logging.c
@@ -1,35 +1,71 @@
 #include "logging.h"
-#include <stdlib.h>
-#include <stdarg.h>
+
 #include "SEGGER_RTT.h"
-void fatal(const char* string,...){
+
+#include <stdarg.h>
+#include <stdlib.h>
+
+// Macros for debugging functions so that file and line number info can be included
+
+log_level_t LOG_LEVEL = DEFAULT_LOG_LEVEL;
+
+void fatal_impl(const char *string, ...) {
+    // No log level checking here, since fatal should always be printed
     va_list args;
     va_start(args, string);
-    unsigned int BufferIndex= 0;
-    SEGGER_RTT_vprintf(BufferIndex,string, &args); // Use vprintf to print with variable arguments
-    
-    va_end(args);
-}
-void warning(const char* string,...){
-    va_list args;
-    va_start(args, string);
-    unsigned int BufferIndex= 0;
-    SEGGER_RTT_vprintf(BufferIndex,string, &args); // Use vprintf to print with variable arguments
-    
-    va_end(args);
-}
-void info(char* string,...){
-    va_list args;
-    va_start(args, string);
-    unsigned int BufferIndex= 0;
-    SEGGER_RTT_vprintf(BufferIndex,string, &args); // Use vprintf to print with variable arguments
+    unsigned int BufferIndex = 0;
+    SEGGER_RTT_vprintf(BufferIndex, string, &args); // Use vprintf to print with variable arguments
+    // TODO: Gracefully shut down the system and then kick the watchdog.
+    while (1) {} // Temporary infinite loop to halt the system (watchdog will eventually kick)
+
     va_end(args);
 }
 
-void debug(const char* string,...){
+void warning_impl(const char *string, ...) {
+    // Check if the log level is high enough to print this message
+    if (WARNING < LOG_LEVEL) {
+        return;
+    }
     va_list args;
     va_start(args, string);
-    unsigned int BufferIndex= 0;
-    SEGGER_RTT_vprintf(BufferIndex,string, &args); // Use vprintf to print with variable arguments
+    unsigned int BufferIndex = 0;
+    SEGGER_RTT_vprintf(BufferIndex, string, &args); // Use vprintf to print with variable arguments
+
+    va_end(args);
+}
+
+void event_impl(const char *string, ...) {
+    // Check if the log level is high enough to print this message
+    if (EVENT < LOG_LEVEL) {
+        return;
+    }
+    va_list args;
+    va_start(args, string);
+    unsigned int BufferIndex = 0;
+    SEGGER_RTT_vprintf(BufferIndex, string, &args); // Use vprintf to print with variable arguments
+    va_end(args);
+}
+
+void info_impl(char *string, ...) {
+    // Check if the log level is high enough to print this message
+    if (INFO < LOG_LEVEL) {
+        return;
+    }
+    va_list args;
+    va_start(args, string);
+    unsigned int BufferIndex = 0;
+    SEGGER_RTT_vprintf(BufferIndex, string, &args); // Use vprintf to print with variable arguments
+    va_end(args);
+}
+
+void debug_impl(const char *string, ...) {
+    // Check if the log level is high enough to print this message
+    if (DEBUG < LOG_LEVEL) {
+        return;
+    }
+    va_list args;
+    va_start(args, string);
+    unsigned int BufferIndex = 0;
+    SEGGER_RTT_vprintf(BufferIndex, string, &args); // Use vprintf to print with variable arguments
     va_end(args);
 }

--- a/src/misc/logging/logging.h
+++ b/src/misc/logging/logging.h
@@ -1,9 +1,46 @@
 #ifndef LOGIN_H
 #define LOGIN_H
 
+#include "globals.h"
 
-void fatal(const char* string, ...);//worst case restart
-void warning(const char* string, ...);//second 
-void info(char* string,...);//something happened
-void debug(const char* string,...);// something small 
+/*
+FATAL: Worst class of errors that will cause a system restart (e.g. memory corruption, stack overflow, critical function fails)
+WARNING: Something unexpected/bad, but recoverable (e.g. failed to take a photo, message checksum invalid)
+EVENT: Significant event (e.g. switching power modes, antenna deployed, photo taken, connection established with ground)
+INFO: Minor event (e.g. message received, task started, attitude recalculated)
+DEBUG: Detailed information about the system for debugging (e.g. length of array is 5, watchdog checked in, mutex locked/unlocked)
+*/
+
+// This should never actually execute when building PVDX
+// __FILENAME__ is a custom macro defined per-file at compile time, so the IDE doesn't know about it
+// To stop the IDE from freaking out, we define it here
+#ifndef __FILENAME__
+    #if defined(DEVBUILD) || defined(UNITTEST) || defined(RELEASE)
+        #error "__FILENAME__ macro should be defined during real builds!"
+    #endif
+    #define __FILENAME__ "<Filename Resolved at Compile Time>"
+#endif
+
+#if defined(DEVBUILD)
+    /* Devbuild should include filenames and line numbers */
+    #define fatal(msg, ...) fatal_impl("[FATAL|%s:%d]: " msg, __FILENAME__, __LINE__, ##__VA_ARGS__)
+    #define warning(msg, ...) warning_impl("[WARNING|%s:%d]: " msg, __FILENAME__, __LINE__, ##__VA_ARGS__)
+    #define event(msg, ...) event_impl("[EVENT|%s:%d]: " msg, __FILENAME__, __LINE__, ##__VA_ARGS__)
+    #define info(msg, ...) info_impl("[INFO|%s:%d]: " msg, __FILENAME__, __LINE__, ##__VA_ARGS__)
+    #define debug(msg, ...) debug_impl("[DEBUG|%s:%d]: " msg, __FILENAME__, __LINE__, ##__VA_ARGS__)
+#else
+    /* Other build types (such as release or unittest) don't need filenames or line numbers */
+    #define fatal(msg, ...) fatal_impl("[FATAL]: " msg, ##__VA_ARGS__)
+    #define warning(msg, ...) warning_impl("[WARNING]: " msg, ##__VA_ARGS__)
+    #define event(msg, ...) event_impl("[EVENT]: " msg, ##__VA_ARGS__)
+    #define info(msg, ...) info_impl("[INFO]: " msg, ##__VA_ARGS__)
+    #define debug(msg, ...) debug_impl("[DEBUG]: " msg, ##__VA_ARGS__)
+#endif
+
+void fatal_impl(const char *string, ...);
+void warning_impl(const char *string, ...);
+void event_impl(const char *string, ...);
+void info_impl(char *string, ...);
+void debug_impl(const char *string, ...);
+
 #endif


### PR DESCRIPTION
- Add new category of logging, `EVENT`, along with a brief comment in logging.h about when each logging tier should be used
- Add compile-time macros for the filename of the current file
- Add macros that expand debugging calls to include file and line info: i.e. `info(XXX)` turns into `info_impl(__FILENAME__, __LINE__, XXX)`