### PR TITLE
Bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,10 @@ flash_bootloader:
 	$(MAKE) -C ./bootloader clean
 	$(MAKE) -C ./bootloader # Builds the bootloader
 ifeq (,$(findstring microsoft,$(shell uname -r))) #Detects a WSL kernel name, and runs a WSL-specific command for connecting to the GDB server
-	@gdb -ex "target remote localhost:2331" -ex "load" -ex "monitor halt" -ex "monitor reset" ./bootloader/bootloader.elf
+	@gdb -ex "target remote localhost:2331" -ex "load" -ex "monitor halt" -ex "monitor reset" -ex "set confirm off" -ex "add-symbol-file PVDXos.elf" -ex "set confirm on" ./bootloader/bootloader.elf
 else #Run the windows-specific command
 	@hostname=$(shell hostname) && \
-	gdb-multiarch -ex "target remote $$hostname.local:2331" -ex "load" -ex "monitor halt" -ex "monitor reset" ./bootloader/bootloader.elf
+	gdb-multiarch -ex "target remote $$hostname.local:2331" -ex "load" -ex "monitor halt" -ex "monitor reset" -ex "set confirm off" -ex "add-symbol-file PVDXos.elf" -ex "set confirm on" ./bootloader/bootloader.elf
 endif
 
 

--- a/bootloader/bootloader.h
+++ b/bootloader/bootloader.h
@@ -9,8 +9,15 @@
 #define SCS_BASE (0xE000E000UL)
 #define SCB_BASE (SCS_BASE + 0x0D00UL)
 #define SCB_VTOR (SCB_BASE + 0x08) // VTOR: Vector Table Offset Register (where the processor will reset from)
+#define SCB_AIRCR (SCB_BASE + 0x0C) // AIRCR Contains SYSRESETREQ bit to request a system reset
 
 #define SCB_VTOR_TBLOFF_Msk (0xFFFFFF80UL) // Mask off the last 7 bits (128 bytes alignment)
+
+#define SCB_AIRCR_VECTKEY_Pos 16U
+#define SCB_AIRCR_SYSRESETREQ_Pos 2U
+#define SCB_AIRCR_SYSRESETREQ_Msk (1UL << SCB_AIRCR_SYSRESETREQ_Pos)
+
+#define RSTC_RCAUSE (0x40000C00UL + 0x00UL) // Reset Cause Register
 
 #define FLASH_START (0UL)
 #define FLASH_SIZE (0x100000UL) // 1MB

--- a/bootloader/linkerscript.ld
+++ b/bootloader/linkerscript.ld
@@ -50,7 +50,7 @@ SECTIONS
   .stack (NOLOAD) :
   {
     . = ALIGN(8);
-    . = . + 0x1000;      /* Adjust stack size as needed */
+    . = . + 0x10000;      /* No memory issues here, just define a big 10KiB stack */
     _estack = .;        /* Define stack top symbol */
   } > RAM
 }

--- a/bootloader/startup.s
+++ b/bootloader/startup.s
@@ -7,9 +7,16 @@
 _start:
     .word _estack            /* Top of stack -- Defined in the linker file*/
     .word bootloader_rst     /* Reset Handler -- First code that runs */
+    .word bootloader_hardfault     /* Hard Fault Handler */
+    .word bootloader_hardfault     /* Add this back in two more times, since sometimes the watchdog reset leads to the hardfault handler getting called */
     /* Other handlers can be added to the vector table if needed, but probably not needed */
 
     .section .text
+bootloader_hardfault:
+    /* Hard fault handler */
+    nop
+    nop
+    /* For now, just fallthrough to the reset handler */
 bootloader_rst:
     /* Initialize data section */
     ldr r0, =_sdata /* points to RAM */

--- a/bootloader/startup.s
+++ b/bootloader/startup.s
@@ -5,18 +5,12 @@
     .globl _start
     .section .isr_vector, "a", %progbits
 _start:
-    .word _estack            /* Top of stack -- Defined in the linker file*/
-    .word bootloader_rst     /* Reset Handler -- First code that runs */
-    .word bootloader_hardfault     /* Hard Fault Handler */
-    .word bootloader_hardfault     /* Add this back in two more times, since sometimes the watchdog reset leads to the hardfault handler getting called */
+    .word _estack                /* Top of stack -- Defined in the linker file*/
+    .word bootloader_rst + 1     /* Reset Handler -- First code that runs */
+    /* We use bootloader_rst + 1 because the LSB of the address is used to determine the instruction set, and it needs to be 1 for ARM Thumb-2 instructions */
     /* Other handlers can be added to the vector table if needed, but probably not needed */
 
     .section .text
-bootloader_hardfault:
-    /* Hard fault handler */
-    nop
-    nop
-    /* For now, just fallthrough to the reset handler */
 bootloader_rst:
     /* Initialize data section */
     ldr r0, =_sdata /* points to RAM */

--- a/src/tasks/watchdog/watchdog_main.c
+++ b/src/tasks/watchdog/watchdog_main.c
@@ -28,7 +28,7 @@ void watchdog_main(void *pvParameters) {
         watchdog_checkin(WATCHDOG_TASK); // Watchdog checks in with itself
 
         // if we get here, then all tasks have checked in within the allowed time
-        // watchdog_pet();
+        watchdog_pet();
         vTaskDelay(pdMS_TO_TICKS(WATCHDOG_MS_DELAY));
     }
 }

--- a/src/tasks/watchdog/watchdog_main.c
+++ b/src/tasks/watchdog/watchdog_main.c
@@ -26,9 +26,9 @@ void watchdog_main(void *pvParameters) {
         }
 
         watchdog_checkin(WATCHDOG_TASK); // Watchdog checks in with itself
-        
+
         // if we get here, then all tasks have checked in within the allowed time
-        watchdog_pet();
+        // watchdog_pet();
         vTaskDelay(pdMS_TO_TICKS(WATCHDOG_MS_DELAY));
     }
 }


### PR DESCRIPTION
- Fix a bootloader bug that would appear when a watchdog reset happens
BUGFIX: The bug was that I was redirecting execution to the `bootloader_rst` at address `0x5C`, but ARM CPUs ignore the last bit of addresses, and use that last bit to determine the instruction set (Full 32-bit ARM instructions VS 16-bit Thumb instructions). Because of this, I needed to actually point the processor to `0x5D` so that the LSB of the address is 1.