### PR TITLE
Makefile now generates objects and include dirs automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+PVDXOS_DIR = $(CURDIR)
+
+export PVDXOS_DIR
+
 ifeq ($(OS),Windows_NT)
 	# Pure Windows (e.g. MSYS2/MinGW). Note that in WSL, $(OS) is *not* Windows_NT.
 	GDBCMD = gdb-multiarch
@@ -43,6 +47,9 @@ test: bootloader_target
 
 flash_monkey:
 	python3 scripts/flip_rand_bit.py
+
+list_files:
+	make -C src list_files
 
 # this command will start gdb from a breakpoint at main
 # use connect_bl to start from the beginning

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,165 +1,34 @@
-###############################################################################
-##################### ADDING SOMETHING?  READ THIS FIRST! #####################
-###############################################################################
-###
-###  When adding a new C file to the source, you must do 2 things:
-###    - Add the file to the OBJS list below (with a .o extension)
-###    - If it is in a new directory, Add the directory to the EXTRA_VPATH list below (with a .c extension)
-###  Remember to add the trailing \ to the end of each line!
-###
-###############################################################################
-###############################################################################
-###############################################################################
+##############################################################################
+################## OBJECT FILE AND INCLUDE PATH DISCOVERY ####################
+##############################################################################
 
-### ALL C FILES SHOULD HAVE AN OBJECT FILE LISTED HERE ###
-export OBJS :=                                              	\
-../src/linalg/LinearAlgebra/add.o 								\
-../src/linalg/LinearAlgebra/chol.o 								\
-../src/linalg/LinearAlgebra/cofact.o 							\
-../src/linalg/LinearAlgebra/copy.o 								\
-../src/linalg/LinearAlgebra/cut.o 								\
-../src/linalg/LinearAlgebra/det.o 								\
-../src/linalg/LinearAlgebra/diag.o 								\
-../src/linalg/LinearAlgebra/diagpower.o 						\
-../src/linalg/LinearAlgebra/dot.o 								\
-../src/linalg/LinearAlgebra/eabs.o 								\
-../src/linalg/LinearAlgebra/eig.o 								\
-../src/linalg/LinearAlgebra/eye.o 								\
-../src/linalg/LinearAlgebra/hankel.o 							\
-../src/linalg/LinearAlgebra/horzcat.o 							\
-../src/linalg/LinearAlgebra/insert.o 							\
-../src/linalg/LinearAlgebra/inv.o								\
-../src/linalg/LinearAlgebra/linprog.o 							\
-../src/linalg/LinearAlgebra/linsolve.o 							\
-../src/linalg/LinearAlgebra/lu.o 								\
-../src/linalg/LinearAlgebra/maxvector.o 						\
-../src/linalg/LinearAlgebra/mdiag.o 							\
-../src/linalg/LinearAlgebra/minvector.o 						\
-../src/linalg/LinearAlgebra/move.o 								\
-../src/linalg/LinearAlgebra/mpower.o 							\
-../src/linalg/LinearAlgebra/mul.o 								\
-../src/linalg/LinearAlgebra/norm.o 								\
-../src/linalg/LinearAlgebra/ones.o 								\
-../src/linalg/LinearAlgebra/pinv.o 								\
-../src/linalg/LinearAlgebra/power.o 							\
-../src/linalg/LinearAlgebra/print.o 							\
-../src/linalg/LinearAlgebra/qr.o 								\
-../src/linalg/LinearAlgebra/rank.o 								\
-../src/linalg/LinearAlgebra/repmat.o 							\
-../src/linalg/LinearAlgebra/scale.o 							\
-../src/linalg/LinearAlgebra/sqrte.o 							\
-../src/linalg/LinearAlgebra/sub.o 								\
-../src/linalg/LinearAlgebra/sumrows.o 							\
-../src/linalg/LinearAlgebra/svd.o 								\
-../src/linalg/LinearAlgebra/toeplitz.o 							\
-../src/linalg/LinearAlgebra/tran.o 								\
-../src/linalg/LinearAlgebra/tril.o 								\
-../src/linalg/LinearAlgebra/triu.o 								\
-../src/linalg/LinearAlgebra/vec.o 								\
-../src/linalg/LinearAlgebra/vertcat.o 							\
-../src/linalg/LinearAlgebra/zeros.o 							\
-../src/linalg/LinearAlgebra/eps.o 								\
-																\
-../src/main.o                                               	\
-                                                            	\
-../src/mutexes/mutexes.o                                    	\
-                                                            	\
-../src/misc/printf/SEGGER_RTT.o                             	\
-../src/misc/printf/SEGGER_RTT_printf.o                      	\
-                                                            	\
-../src/misc/rtos_support/rtos_static_memory.o               	\
-../src/misc/rtos_support/rtos_stack_overflow.o              	\
-                                                            	\
-../src/misc/logging/logging.o                               	\
-                                                            	\
-../src/misc/exception_handlers/default_handler.o            	\
-../src/misc/exception_handlers/specific_handlers.o          	\
-																\
-../src/drivers/display/display_driver.o                       	\
-../src/drivers/gyro/SCH1.o										\
-../src/drivers/magnetometer/magnetometer_driver.o           	\
-../src/drivers/photodiode/photodiode_driver.o               	\
-../src/drivers/rtc/rtc_driver.o                                 \
-../src/drivers/watchdog/watchdog_driver.o                     	\
-../src/drivers/at86rf215/at86rf215.o								\
-                                                            	\
-../src/tasks/heartbeat/heartbeat_main.o                     	\
-                                                            	\
-../src/tasks/watchdog/watchdog_task.o                       	\
-../src/tasks/watchdog/watchdog_main.o                       	\
-                                                            	\
-../src/tasks/cosmic_monkey/cosmic_monkey_main.o             	\
-../src/tasks/cosmic_monkey/cosmic_monkey_task.o             	\
-                                                            	\
-../src/tasks/display/display_task.o                         	\
-../src/tasks/display/display_main.o                         	\
-../src/tasks/display/image_buffers/image_buffer_BrownLogo.o 	\
-../src/tasks/display/image_buffers/image_buffer_PVDX.o      	\
-../src/tasks/adcs/adcs_task.o 									\
-../src/tasks/adcs/adcs_main.o 									\
-                                                            	\
-../src/tasks/task_manager/task_manager_main.o               	\
-../src/tasks/task_manager/task_manager_task.o               	\
-                                                            	\
-../src/tasks/command_dispatcher/command_dispatcher_main.o   	\
-../src/tasks/command_dispatcher/command_dispatcher_task.o   	\
-                                                            	\
-../src/tasks/shell/shell_main.o                             	\
-../src/tasks/shell/shell_helpers.o                          	\
-../src/tasks/shell/shell_commands.o                         	\
-                                                            	\
-../src/tasks/task_list.o                                        \
-																\
-../src/checks/device_checks.o 									\
-																\
-../src/ccsds/spp.o 										\
-../src/ccsds/cfdp_pdu.o 									\
-../src/tests/test.o                                             \
-																
+# list of directories and files to exclude from compilation
+EXCLUDE_PATHS := $(PVDXOS_DIR)/src/libraries/adcs \
+				 $(PVDXOS_DIR)/src/linalg/Lapack \
 
-### ALL DIRECTORIES WITH SOURCE FILES MUST BE LISTED HERE ###
-### THESE ARE WRITTEN RELATIVE TO THE ./ASF/gcc/Makefile FILE ###
-export EXTRA_VPATH := \
-../../src \
-../../src/misc \
-../../src/misc/printf \
-../../src/misc/rtos_support \
-../../src/misc/logging \
-../../src/misc/exception_handlers \
-../../src/drivers \
-../../src/drivers/display \
-../../src/drivers/gyro \
-../../src/drivers/magnetometer \
-../../src/drivers/magnetorquer \
-../../src/drivers/at86rf215    \
-../../src/drivers/rtc \
-../../src/drivers/photodiode \
-../../src/drivers/watchdog \
-../../src/tasks \
-../../src/tasks/watchdog \
-../../src/tasks/heartbeat \
-../../src/tasks/cosmic_monkey \
-../../src/tasks/display \
-../../src/tasks/display/image_buffers \
-../../src/tasks/task_manager \
-../../src/tasks/command_dispatcher \
-../../src/tasks/shell \
-../../src/tasks/radio \
-../../src/tasks/adcs \
-../../src/mutexes \
-../../src/checks \
-../../src/ccsds \
-../../src/tests \
-../../src/linalg \
-../../src/linalg/Lapack \
-../../src/linalg/LinearAlgebra \
-../../src/tasks/adcs \
-../../src/mutexes
+# generate flags to pass to find to exclude paths from above
+EXCLUDE_FLAGS := $(foreach dir,$(EXCLUDE_PATHS),-not -path "$(dir)/*")
 
-###############################################################################
-###############################################################################
-###############################################################################
+# Discover all c files in src dir
+SRCS := $(shell find $(PVDXOS_DIR)/src -name "*.c" $(EXCLUDE_FLAGS))
 
+# Substitute .c suffix with .o to create output object names
+export OBJS := $(patsubst %.c,%.o,$(SRCS))
+
+# Create list of directories to include from
+export EXTRA_VPATH := $(sort $(dir $(SRCS)))
+
+# Print discovered objs and VPATH for debugging 
+$(info Parsed OBJS:)
+$(eval $(foreach f,$(OBJS),$(info $(f))))
+
+$(info Parsed EXTRA_VPATH:)
+$(eval $(foreach f,$(EXTRA_VPATH),$(info $(f))))
+
+##############################################################################
+##############################################################################
+##############################################################################
+ 
 #Technical stuff
 
 #Makefile usually uses /bin/sh to evaluate commands, so we need to change it to /bin/bash
@@ -259,6 +128,11 @@ clean:
 	@$(MAKE) -C $(CHILD_MAKEFILE_PATH) clean \
 	&& rm -f ./PVDXos.bin ./PVDXos.elf \
 	&& echo " --- Cleaned Build Files --- "
+
+# this is a cheat, since it's just a nop. Execution stops after 
+# info statements at the top of Makefile
+list_files:
+	@: 
 
 # When updating the ASF configuration, this must be run once in order to automatically integrate the new ASF config
 # Hopefully nobody ever needs to touch this, but you can add to it if you want to automatically trigger an action when the ASF is updated

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,11 @@
 # list of directories and files to exclude from compilation
 EXCLUDE_PATHS := $(PVDXOS_DIR)/src/libraries/adcs \
 				 $(PVDXOS_DIR)/src/linalg/Lapack \
+				 $(PVDXOS_DIR)/src/linalg/LinearAlgebra/quadprog.c \
+				 $(PVDXOS_DIR)/src/linalg/LinearAlgebra/kf.c \
+				 $(PVDXOS_DIR)/src/tests/test_linalg.c \
+				 $(PVDXOS_DIR)/src/tasks/radio \
+				 $(PVDXOS_DIR)/src/drivers/magnetorquer \
 
 # generate flags to pass to find to exclude paths from above
 EXCLUDE_FLAGS := $(foreach dir,$(EXCLUDE_PATHS),-not -path "$(dir)/*")

--- a/src/linalg/Lapack/Scr/sorm2r.c
+++ b/src/linalg/Lapack/Scr/sorm2r.c
@@ -180,7 +180,7 @@ static integer c__1 = 1;
         return 0;
     }
 
-    if (left && !notran || !left && notran) {
+    if ((left && !notran) || !left && notran) {
         i1 = 1;
         i2 = *k;
         i3 = 1;

--- a/src/tests/test.c
+++ b/src/tests/test.c
@@ -1,9 +1,8 @@
 
-#include "tests/test.h"
-
-#include "ccsds/cfdp_pdu.h"
-#include "ccsds/spp.h"
-#include "linalg/LinearAlgebra/declareFunctions.h"
+#include "test.h"
+#include "test_linalg.h"
+#include "cfdp_pdu.h"
+#include "spp.h"
 #include "logging.h"
 
 int tests_passed = 0;
@@ -45,74 +44,6 @@ void test_spp(void) {
 
     test_log("data_length: %x\n", packet.header.data_length);
     PVDX_ASSERT_MSG(packet.header.data_length == 0xAA, "data_length");
-}
-
-void test_matrix_product(void) {
-    test_log("----- testing matrix product -----\n");
-
-    // test case for 2*2 matrix product
-    float A[4] = {1., 2., 3., 4.};
-    float B[4] = {5., 6., 7., 8.};
-    float C[4] = {0.};
-    float C_expected[4] = {19., 22., 43., 50.};
-
-    mul(A, B, false, C, 2, 2, 2);
-    // log_matrix(C, 2, 2);
-
-    if (dbl_eps_close_matrix(C, C_expected, 2, 2, DBL_EPSILON)) {
-        test_log("1 * 2 matrix product test passed!\n");
-    } else {
-        test_log("2 * 2 matrix product test failed!\n");
-    }
-
-    // 4*4 identity matrix test
-    float identity[4 * 4] = {0.};
-    float large_result[4 * 4] = {0.};
-
-    eye(identity, 4, 4);
-
-    mul(identity, identity, false, large_result, 4, 4, 4);
-
-    if (dbl_eps_close_matrix(identity, large_result, 4, 4, DBL_EPSILON)) {
-        test_log("Identity matrix squared test passed!\n");
-    } else {
-        test_log("Identity matrix squared test failed!\n");
-    }
-
-    float A_large[4 * 4] = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., 13., 14., 15., 16.};
-
-    mul(A_large, identity, false, large_result, 4, 4, 4);
-
-    if (dbl_eps_close_matrix(A_large, large_result, 4, 4, DBL_EPSILON)) {
-        test_log("Identity post-multiplication test passed!\n");
-    } else {
-        test_log("Identity post-multiplication test failed!\n");
-    }
-
-    mul(identity, A_large, false, large_result, 4, 4, 4);
-
-    if (dbl_eps_close_matrix(A_large, large_result, 4, 4, DBL_EPSILON)) {
-        test_log("Identity pre-multiplication test passed!\n");
-    } else {
-        test_log("Identity pre-multiplication test failed!\n");
-    }
-
-    float B_large[4 * 4] = {5.24829, 6.21496, 3.27374, 3.49223, 1.52040, 3.70849, 7.21884, 0.41667,
-                            7.77438, 8.24807, 8.63347, 2.01096, 8.29170, 1.46735, 8.53606, 5.14221};
-
-    float C_large[4 * 4] = {1.92304, 0.14043, 1.64762, 4.97396, 0.68077, 4.99275, 7.04041, 2.44857,
-                            8.22049, 1.66745, 7.94150, 0.56302, 2.68638, 7.59450, 1.43236, 3.59834};
-
-    float large_multiplication_expected[4 * 4] = {50.6168, 63.7473, 83.4036, 55.732,  65.9102, 33.9305, 86.5396, 22.2066,
-                                                  96.939,  71.9404, 142.322, 70.9624, 100.929, 61.7765, 99.1469, 68.1449};
-
-    mul(B_large, C_large, false, large_result, 4, 4, 4);
-
-    if (dbl_eps_close_matrix(large_result, large_multiplication_expected, 4, 4, DBL_EPSILON)) {
-        test_log("Large matrix product test passed!\n");
-    } else {
-        test_log("Large matrix product test failed!\n");
-    }
 }
 
 void test_cfdp(void) {

--- a/src/tests/test_linalg.c
+++ b/src/tests/test_linalg.c
@@ -9,27 +9,9 @@
 
 #include "test_linalg.h"
 
-#include "linalg/LinearAlgebra/declareFunctions.h"
+#include "declareFunctions.h"
 #include "logging.h"
 
-/**
- * \fn debug_matrix
- *
- * \brief Debug prints a matrix A, with the dimension row x column
- *
- * \param A the matrix to print (as a 1D array in row-major order)
- * \param row the number of rows in the matrix
- * \param column the number of columns in the matrix
- */
-void debug_matrix(float *A, int row, int column) {
-    for (int i = 0; i < row; i++) {
-        for (int j = 0; j < column; j++) {
-            printf("%0.18f ", *(A++));
-        }
-        printf("\n");
-    }
-    printf("\n");
-}
 
 void test_matrix_product(void) {
     test_log("----- testing matrix product -----\n");

--- a/src/tests/test_linalg.c
+++ b/src/tests/test_linalg.c
@@ -8,7 +8,7 @@
  */
 
 #include "test_linalg.h"
-
+#include "stdbool.h"
 #include "declareFunctions.h"
 #include "logging.h"
 


### PR DESCRIPTION
deltas:
- added PVDXOS_DIR variable to top-level Makefile, exported down to child makefiles
- `src` Makefile now `find`s any .c files in `src` to generate `OBJS` variable; `EXTRA_VPATH` includes all paths where .c files have been found 
- also defines `EXCLUDE_PATH` in `src` Makefile to exclude compilation-unready files from globbing. 