### PR TITLE
Finish at86rf215 QPSK driver

### DIFF
--- a/src/drivers/at86rf215/.clang-format
+++ b/src/drivers/at86rf215/.clang-format
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: GPL-3.0
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+StatementAttributeLikeMacros:
+  - Q_EMIT
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+ReferenceAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/src/drivers/at86rf215/at86rf215.c
+++ b/src/drivers/at86rf215/at86rf215.c
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "at86rf215_helpers.h"
 #include "globals.h"
@@ -39,55 +40,65 @@ uint8_t uhf_spi_tx_buffer[UHF_SPI_BUF_SIZE] = {0x00};
 #define INIT_MAGIC_VAL 0x92c2f0e3
 
 #ifndef max
-    #define max(a, b)                                                                                                                      \
-        ({                                                                                                                                 \
-            __typeof__(a) _a = (a);                                                                                                        \
-            __typeof__(b) _b = (b);                                                                                                        \
-            _a > _b ? _a : _b;                                                                                                             \
-        })
+#define max(a, b)                                                              \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    _a > _b ? _a : _b;                                                         \
+  })
 #endif
 
 #ifndef min
-    #define min(a, b)                                                                                                                      \
-        ({                                                                                                                                 \
-            __typeof__(a) _a = (a);                                                                                                        \
-            __typeof__(b) _b = (b);                                                                                                        \
-            _a < _b ? _a : _b;                                                                                                             \
-        })
+#define min(a, b)                                                              \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    _a < _b ? _a : _b;                                                         \
+  })
 #endif
 
 #define BIT(n) (1UL << (n))
 
 /* Table 6.60 to 6.63 definitions */
 
-static const at86rf215_rcut_t fsk_tx_conf_rcut_midx1[6] = {AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2,
-                                                           AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2};
-static const at86rf215_rcut_t fsk_tx_conf_rcut_midx3[6] = {AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2,
-                                                           AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2};
+static const at86rf215_rcut_t fsk_tx_conf_rcut_midx1[6] = {
+    AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2,
+    AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2};
+static const at86rf215_rcut_t fsk_tx_conf_rcut_midx3[6] = {
+    AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2,
+    AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2, AT86RF215_RCUT_100FS2};
 
-static const at86rf215_rcut_t fsk_rx_conf_rcut_midx1_09[6] = {AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2,
-                                                              AT86RF215_RCUT_37FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2};
-static const at86rf215_rcut_t fsk_rx_conf_rcut_midx1_24[6] = {AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2,
-                                                              AT86RF215_RCUT_37FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_37FS2};
+static const at86rf215_rcut_t fsk_rx_conf_rcut_midx1_09[6] = {
+    AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2,
+    AT86RF215_RCUT_37FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2};
+static const at86rf215_rcut_t fsk_rx_conf_rcut_midx1_24[6] = {
+    AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_25FS2,
+    AT86RF215_RCUT_37FS2, AT86RF215_RCUT_25FS2, AT86RF215_RCUT_37FS2};
 
-static const at86rf215_rcut_t fsk_rx_conf_rcut_midx3_09[6] = {AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2,
-                                                              AT86RF215_RCUT_50FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2};
-static const at86rf215_rcut_t fsk_rx_conf_rcut_midx3_24[6] = {AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_50FS2,
-                                                              AT86RF215_RCUT_75FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_50FS2};
+static const at86rf215_rcut_t fsk_rx_conf_rcut_midx3_09[6] = {
+    AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2,
+    AT86RF215_RCUT_50FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2};
+static const at86rf215_rcut_t fsk_rx_conf_rcut_midx3_24[6] = {
+    AT86RF215_RCUT_37FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_50FS2,
+    AT86RF215_RCUT_75FS2, AT86RF215_RCUT_37FS2, AT86RF215_RCUT_50FS2};
 
-static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx1_09[6] = {AT86RF215_RF_BW160KHZ_IF250KHZ, AT86RF215_RF_BW200KHZ_IF250KHZ,
-                                                              AT86RF215_RF_BW320KHZ_IF500KHZ, AT86RF215_RF_BW320KHZ_IF500KHZ,
-                                                              AT86RF215_RF_BW500KHZ_IF500KHZ, AT86RF215_RF_BW630KHZ_IF1000KHZ};
-static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx1_24[6] = {AT86RF215_RF_BW160KHZ_IF250KHZ,  AT86RF215_RF_BW200KHZ_IF250KHZ,
-                                                              AT86RF215_RF_BW320KHZ_IF500KHZ,  AT86RF215_RF_BW400KHZ_IF500KHZ,
-                                                              AT86RF215_RF_BW630KHZ_IF1000KHZ, AT86RF215_RF_BW800KHZ_IF1000KHZ};
+static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx1_09[6] = {
+    AT86RF215_RF_BW160KHZ_IF250KHZ, AT86RF215_RF_BW200KHZ_IF250KHZ,
+    AT86RF215_RF_BW320KHZ_IF500KHZ, AT86RF215_RF_BW320KHZ_IF500KHZ,
+    AT86RF215_RF_BW500KHZ_IF500KHZ, AT86RF215_RF_BW630KHZ_IF1000KHZ};
+static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx1_24[6] = {
+    AT86RF215_RF_BW160KHZ_IF250KHZ,  AT86RF215_RF_BW200KHZ_IF250KHZ,
+    AT86RF215_RF_BW320KHZ_IF500KHZ,  AT86RF215_RF_BW400KHZ_IF500KHZ,
+    AT86RF215_RF_BW630KHZ_IF1000KHZ, AT86RF215_RF_BW800KHZ_IF1000KHZ};
 
-static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx3_09[6] = {AT86RF215_RF_BW160KHZ_IF250KHZ,  AT86RF215_RF_BW320KHZ_IF500KHZ,
-                                                              AT86RF215_RF_BW400KHZ_IF500KHZ,  AT86RF215_RF_BW500KHZ_IF500KHZ,
-                                                              AT86RF215_RF_BW630KHZ_IF1000KHZ, AT86RF215_RF_BW1000KHZ_IF1000KHZ};
-static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx3_24[6] = {AT86RF215_RF_BW200KHZ_IF250KHZ,  AT86RF215_RF_BW400KHZ_IF500KHZ,
-                                                              AT86RF215_RF_BW630KHZ_IF1000KHZ, AT86RF215_RF_BW630KHZ_IF1000KHZ,
-                                                              AT86RF215_RF_BW800KHZ_IF1000KHZ, AT86RF215_RF_BW1000KHZ_IF1000KHZ};
+static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx3_09[6] = {
+    AT86RF215_RF_BW160KHZ_IF250KHZ,  AT86RF215_RF_BW320KHZ_IF500KHZ,
+    AT86RF215_RF_BW400KHZ_IF500KHZ,  AT86RF215_RF_BW500KHZ_IF500KHZ,
+    AT86RF215_RF_BW630KHZ_IF1000KHZ, AT86RF215_RF_BW1000KHZ_IF1000KHZ};
+static const at86rf215_rx_bw_t fsk_rx_conf_rbw_midx3_24[6] = {
+    AT86RF215_RF_BW200KHZ_IF250KHZ,  AT86RF215_RF_BW400KHZ_IF500KHZ,
+    AT86RF215_RF_BW630KHZ_IF1000KHZ, AT86RF215_RF_BW630KHZ_IF1000KHZ,
+    AT86RF215_RF_BW800KHZ_IF1000KHZ, AT86RF215_RF_BW1000KHZ_IF1000KHZ};
 
 static const uint8_t fsk_rx_conf_ifs_midx1_09[6] = {0, 0, 0, 0, 1, 0};
 static const uint8_t fsk_rx_conf_ifs_midx1_24[6] = {0, 0, 0, 0, 0, 0};
@@ -100,14 +111,16 @@ static const uint8_t fsk_rx_conf_ifs_midx3_24[6] = {0, 0, 0, 0, 0, 1};
  * @param h the device handle
  * @return 0 on success or negative error code
  */
-static int ready(struct at86rf215 *h) {
-    if (!h) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    if (h->priv.init != INIT_MAGIC_VAL) {
-        return -AT86RF215_NO_INIT;
-    }
-    return AT86RF215_OK;
+static int
+ready(struct at86rf215 *h)
+{
+  if (!h) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  if (h->priv.init != INIT_MAGIC_VAL) {
+    return -AT86RF215_NO_INIT;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -116,22 +129,24 @@ static int ready(struct at86rf215 *h) {
  * @param radio the RF frontend
  * @return 0 on success or negative error code
  */
-static int supports_rf(struct at86rf215 *h, at86rf215_radio_t radio) {
-    int ret = ready(h);
-    if (ret) {
-        return ret;
-    }
-    switch (radio) {
-        case AT86RF215_RF09:
-        case AT86RF215_RF24:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    if (radio == AT86RF215_RF24 && h->priv.family == AT86RF215M) {
-        return -AT86RF215_NOT_SUPPORTED;
-    }
-    return AT86RF215_OK;
+static int
+supports_rf(struct at86rf215 *h, at86rf215_radio_t radio)
+{
+  int ret = ready(h);
+  if (ret) {
+    return ret;
+  }
+  switch (radio) {
+  case AT86RF215_RF09:
+  case AT86RF215_RF24:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  if (radio == AT86RF215_RF24 && h->priv.family == AT86RF215M) {
+    return -AT86RF215_NOT_SUPPORTED;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -140,27 +155,29 @@ static int supports_rf(struct at86rf215 *h, at86rf215_radio_t radio) {
  * @param radio the RF frontend
  * @return 0 on success or negative error code
  */
-static int supports_mode(struct at86rf215 *h, at86rf215_chpm_t mode) {
-    int ret = ready(h);
-    if (ret) {
-        return ret;
-    }
-    switch (mode) {
-        case AT86RF215_RF_MODE_BBRF:
-        case AT86RF215_RF_MODE_RF:
-        case AT86RF215_RF_MODE_BBRF09:
-        case AT86RF215_RF_MODE_BBRF24:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    if (h->priv.family == AT86RF215IQ && mode != AT86RF215_RF_MODE_RF) {
-        return -AT86RF215_NOT_SUPPORTED;
-    }
-    if (h->priv.family == AT86RF215M && mode == AT86RF215_RF_MODE_BBRF24) {
-        return -AT86RF215_NOT_SUPPORTED;
-    }
-    return AT86RF215_OK;
+static int
+supports_mode(struct at86rf215 *h, at86rf215_chpm_t mode)
+{
+  int ret = ready(h);
+  if (ret) {
+    return ret;
+  }
+  switch (mode) {
+  case AT86RF215_RF_MODE_BBRF:
+  case AT86RF215_RF_MODE_RF:
+  case AT86RF215_RF_MODE_BBRF09:
+  case AT86RF215_RF_MODE_BBRF24:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  if (h->priv.family == AT86RF215IQ && mode != AT86RF215_RF_MODE_RF) {
+    return -AT86RF215_NOT_SUPPORTED;
+  }
+  if (h->priv.family == AT86RF215M && mode == AT86RF215_RF_MODE_BBRF24) {
+    return -AT86RF215_NOT_SUPPORTED;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -170,131 +187,134 @@ static int supports_mode(struct at86rf215 *h, at86rf215_chpm_t mode) {
  * @param os clock output selection
  * @return 0 on success or negative error code
  */
-int at86rf215_init(struct at86rf215 *h) {
-    if (!h) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    /* Reset the state of the private struct members */
-    memset(&h->priv, 0, sizeof(struct at86rf215_priv));
+int
+at86rf215_init(struct at86rf215 *h)
+{
+  if (!h) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  /* Reset the state of the private struct members */
+  memset(&h->priv, 0, sizeof(struct at86rf215_priv));
 
-    at86rf215_irq_enable(h, 0);
-    /* Reset the IC */
-    at86rf215_set_rstn(h, 0);
-    at86rf215_delay_us(h, 1000);
-    at86rf215_set_rstn(h, 1);
-    at86rf215_delay_us(h, 1000);
+  at86rf215_irq_enable(h, 0);
+  /* Reset the IC */
+  at86rf215_set_rstn(h, 0);
+  at86rf215_delay_us(h, 1000);
+  at86rf215_set_rstn(h, 1);
+  at86rf215_delay_us(h, 1000);
 
-    uint8_t val = 0;
-    int ret = at86rf215_reg_read_8(h, &val, REG_RF_PN);
-    if (ret) {
-        return ret;
-    }
-    switch (val) {
-        case AT86RF215:
-        case AT86RF215IQ:
-        case AT86RF215M:
-            h->priv.family = (at86rf215_family_t)val;
-            break;
-        default:
-            return -AT86RF215_UNKNOWN_IC;
-    }
+  uint8_t val = 0;
+  int     ret = at86rf215_reg_read_8(h, &val, REG_RF_PN);
+  if (ret) {
+    return ret;
+  }
+  switch (val) {
+  case AT86RF215:
+  case AT86RF215IQ:
+  case AT86RF215M:
+    h->priv.family = (at86rf215_family_t)val;
+    break;
+  default:
+    return -AT86RF215_UNKNOWN_IC;
+  }
 
-    val = 0;
-    switch (h->clk_drv) {
-        case AT86RF215_RF_DRVCLKO2:
-        case AT86RF215_RF_DRVCLKO4:
-        case AT86RF215_RF_DRVCLKO6:
-        case AT86RF215_RF_DRVCLKO8:
-            val = h->clk_drv << 3;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    switch (h->clko_os) {
-        case AT86RF215_RF_CLKO_OFF:
-        case AT86RF215_RF_CLKO_26_MHZ:
-        case AT86RF215_RF_CLKO_32_MHZ:
-        case AT86RF215_RF_CLKO_16_MHZ:
-        case AT86RF215_RF_CLKO_8_MHZ:
-        case AT86RF215_RF_CLKO_4_MHZ:
-        case AT86RF215_RF_CLKO_2_MHZ:
-        case AT86RF215_RF_CLKO_1_MHZ:
-            val |= h->clko_os;
-            break;
-    }
-    ret = at86rf215_reg_write_8(h, val, REG_RF_CLKO);
-    if (ret) {
-        return ret;
-    }
+  val = 0;
+  switch (h->clk_drv) {
+  case AT86RF215_RF_DRVCLKO2:
+  case AT86RF215_RF_DRVCLKO4:
+  case AT86RF215_RF_DRVCLKO6:
+  case AT86RF215_RF_DRVCLKO8:
+    val = h->clk_drv << 3;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  switch (h->clko_os) {
+  case AT86RF215_RF_CLKO_OFF:
+  case AT86RF215_RF_CLKO_26_MHZ:
+  case AT86RF215_RF_CLKO_32_MHZ:
+  case AT86RF215_RF_CLKO_16_MHZ:
+  case AT86RF215_RF_CLKO_8_MHZ:
+  case AT86RF215_RF_CLKO_4_MHZ:
+  case AT86RF215_RF_CLKO_2_MHZ:
+  case AT86RF215_RF_CLKO_1_MHZ:
+    val |= h->clko_os;
+    break;
+  }
+  ret = at86rf215_reg_write_8(h, val, REG_RF_CLKO);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply XO settings */
-    ret = at86rf215_reg_write_8(h, (h->xo_fs << 4) | h->xo_trim, REG_RF_XOC);
-    if (ret) {
-        return ret;
-    }
+  /* Apply XO settings */
+  ret = at86rf215_reg_write_8(h, (h->xo_fs << 4) | h->xo_trim, REG_RF_XOC);
+  if (ret) {
+    return ret;
+  }
 
-    /* Set the RF_CFG */
-    ret = at86rf215_reg_write_8(h, (h->irqmm << 3) | (h->irqp << 2) | h->pad_drv, REG_RF_CFG);
-    if (ret) {
-        return ret;
-    }
+  /* Set the RF_CFG */
+  ret = at86rf215_reg_write_8(h, (h->irqmm << 3) | (h->irqp << 2) | h->pad_drv,
+                              REG_RF_CFG);
+  if (ret) {
+    return ret;
+  }
 
-    /* Set RF09_PADFE and RF24_PADFE */
-    val = 0;
-    switch (h->rf_femode_09) {
-        case AT86RF215_RF_FEMODE0:
-        case AT86RF215_RF_FEMODE1:
-        case AT86RF215_RF_FEMODE2:
-        case AT86RF215_RF_FEMODE3:
-            val = h->rf_femode_09 << 6;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    ret = at86rf215_reg_write_8(h, val, REG_RF09_PADFE);
-    if (ret) {
-        return ret;
-    }
+  /* Set RF09_PADFE and RF24_PADFE */
+  val = 0;
+  switch (h->rf_femode_09) {
+  case AT86RF215_RF_FEMODE0:
+  case AT86RF215_RF_FEMODE1:
+  case AT86RF215_RF_FEMODE2:
+  case AT86RF215_RF_FEMODE3:
+    val = h->rf_femode_09 << 6;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  ret = at86rf215_reg_write_8(h, val, REG_RF09_PADFE);
+  if (ret) {
+    return ret;
+  }
 
-    val = 0;
-    switch (h->rf_femode_24) {
-        case AT86RF215_RF_FEMODE0:
-        case AT86RF215_RF_FEMODE1:
-        case AT86RF215_RF_FEMODE2:
-        case AT86RF215_RF_FEMODE3:
-            val = h->rf_femode_24 << 6;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    ret = at86rf215_reg_write_8(h, val, REG_RF24_PADFE);
-    if (ret) {
-        return ret;
-    }
+  val = 0;
+  switch (h->rf_femode_24) {
+  case AT86RF215_RF_FEMODE0:
+  case AT86RF215_RF_FEMODE1:
+  case AT86RF215_RF_FEMODE2:
+  case AT86RF215_RF_FEMODE3:
+    val = h->rf_femode_24 << 6;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  ret = at86rf215_reg_write_8(h, val, REG_RF24_PADFE);
+  if (ret) {
+    return ret;
+  }
 
-    /* Get the version of the IC */
-    ret = at86rf215_reg_read_8(h, &val, REG_RF_VN);
-    if (ret) {
-        return ret;
-    }
-    h->priv.version = val;
-    h->priv.chpm = AT86RF215_RF_MODE_BBRF;
-    h->priv.init = INIT_MAGIC_VAL;
+  /* Get the version of the IC */
+  ret = at86rf215_reg_read_8(h, &val, REG_RF_VN);
+  if (ret) {
+    return ret;
+  }
+  h->priv.version = val;
+  h->priv.chpm    = AT86RF215_RF_MODE_BBRF;
+  h->priv.init    = INIT_MAGIC_VAL;
 
-    /*Enable the IRQs that are necessary for the driver */
-    at86rf215_set_bbc_irq_mask(h, AT86RF215_RF09, BIT(4));
-    at86rf215_set_bbc_irq_mask(h, AT86RF215_RF24, BIT(4));
-    at86rf215_set_radio_irq_mask(h, AT86RF215_RF09, BIT(1));
-    at86rf215_set_radio_irq_mask(h, AT86RF215_RF24, BIT(1));
+  /*Enable the IRQs that are necessary for the driver */
+  at86rf215_set_bbc_irq_mask(h, AT86RF215_RF09, BIT(4));
+  at86rf215_set_bbc_irq_mask(h, AT86RF215_RF24, BIT(4));
+  at86rf215_set_radio_irq_mask(h, AT86RF215_RF09, BIT(1));
+  at86rf215_set_radio_irq_mask(h, AT86RF215_RF24, BIT(1));
 
-    /* Assert any active IRQ */
-    at86rf215_reg_read_8(h, &val, REG_RF09_IRQS);
-    at86rf215_reg_read_8(h, &val, REG_RF24_IRQS);
-    at86rf215_reg_read_8(h, &val, REG_BBC0_IRQS);
-    at86rf215_reg_read_8(h, &val, REG_BBC1_IRQS);
+  /* Assert any active IRQ */
+  at86rf215_reg_read_8(h, &val, REG_RF09_IRQS);
+  at86rf215_reg_read_8(h, &val, REG_RF24_IRQS);
+  at86rf215_reg_read_8(h, &val, REG_BBC0_IRQS);
+  at86rf215_reg_read_8(h, &val, REG_BBC1_IRQS);
 
-    at86rf215_irq_enable(h, 1);
-    return AT86RF215_OK;
+  at86rf215_irq_enable(h, 1);
+  return AT86RF215_OK;
 }
 
 /**
@@ -304,20 +324,22 @@ int at86rf215_init(struct at86rf215 *h) {
  * @return 0 on success, -AT86RF215_UNKNOWN_IC if the IC
  * is not one of the known ones, or other negative error code
  */
-int at86rf215_conn_check(struct at86rf215 *h) {
-    uint8_t val = 0;
-    int ret = at86rf215_reg_read_8(h, &val, REG_RF_PN);
-    if (ret) {
-        return ret;
-    }
-    switch (val) {
-        case AT86RF215:
-        case AT86RF215IQ:
-        case AT86RF215M:
-            return AT86RF215_OK;
-        default:
-            return -AT86RF215_UNKNOWN_IC;
-    }
+int
+at86rf215_conn_check(struct at86rf215 *h)
+{
+  uint8_t val = 0;
+  int     ret = at86rf215_reg_read_8(h, &val, REG_RF_PN);
+  if (ret) {
+    return ret;
+  }
+  switch (val) {
+  case AT86RF215:
+  case AT86RF215IQ:
+  case AT86RF215M:
+    return AT86RF215_OK;
+  default:
+    return -AT86RF215_UNKNOWN_IC;
+  }
 }
 
 /**
@@ -327,15 +349,17 @@ int at86rf215_conn_check(struct at86rf215 *h) {
  * @param radio the radio frontend
  * @return 0 on success or negative error code
  */
-static int radio_ready(struct at86rf215 *h, at86rf215_radio_t radio) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (h->priv.radios[radio].init != INIT_MAGIC_VAL) {
-        return -AT86RF215_NO_INIT;
-    }
-    return AT86RF215_OK;
+static int
+radio_ready(struct at86rf215 *h, at86rf215_radio_t radio)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (h->priv.radios[radio].init != INIT_MAGIC_VAL) {
+    return -AT86RF215_NO_INIT;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -345,108 +369,109 @@ static int radio_ready(struct at86rf215 *h, at86rf215_radio_t radio) {
  * @param conf configuration parameters
  * @return 0 on success or negative error code
  */
-int at86rf215_radio_conf(struct at86rf215 *h, at86rf215_radio_t radio, const struct at86rf215_radio_conf *conf) {
-    if (!conf) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    int ret = supports_rf(h, radio);
-    if (ret) {
+int
+at86rf215_radio_conf(struct at86rf215 *h, at86rf215_radio_t radio,
+                     const struct at86rf215_radio_conf *conf)
+{
+  if (!conf) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  uint32_t spacing = conf->cs / 25000;
+  spacing          = min(0xFF, spacing);
+
+  /* Set the channel configuration */
+  if (radio == AT86RF215_RF09) {
+    switch (conf->cm) {
+    case AT86RF215_CM_IEEE: {
+      ret = at86rf215_reg_write_8(h, spacing, REG_RF09_CS);
+      if (ret) {
         return ret;
+      }
+      h->priv.radios[AT86RF215_RF09].cs_reg    = spacing;
+      h->priv.radios[AT86RF215_RF09].base_freq = conf->base_freq;
+      ret = at86rf215_reg_write_8(h, spacing, REG_RF09_CS);
+      if (ret) {
+        return ret;
+      }
+
+      /* Apply base frequency */
+      if (conf->base_freq < 389500000 || conf->base_freq > 1020000000) {
+        return -AT86RF215_INVAL_PARAM;
+      }
+      uint16_t base = conf->base_freq / 25000;
+      ret           = at86rf215_reg_write_8(h, base & 0xFF, REG_RF09_CCF0L);
+      if (ret) {
+        return ret;
+      }
+      ret = at86rf215_reg_write_8(h, base >> 8, REG_RF09_CCF0H);
+      if (ret) {
+        return ret;
+      }
     }
-    uint32_t spacing = conf->cs / 25000;
-    spacing = min(0xFF, spacing);
-
-    /* Set the channel configuration */
-    if (radio == AT86RF215_RF09) {
-        switch (conf->cm) {
-            case AT86RF215_CM_IEEE:
-                {
-                    ret = at86rf215_reg_write_8(h, spacing, REG_RF09_CS);
-                    if (ret) {
-                        return ret;
-                    }
-                    h->priv.radios[AT86RF215_RF09].cs_reg = spacing;
-                    h->priv.radios[AT86RF215_RF09].base_freq = conf->base_freq;
-                    ret = at86rf215_reg_write_8(h, spacing, REG_RF09_CS);
-                    if (ret) {
-                        return ret;
-                    }
-
-                    /* Apply base frequency */
-                    if (conf->base_freq < 389500000 || conf->base_freq > 1020000000) {
-                        return -AT86RF215_INVAL_PARAM;
-                    }
-                    uint16_t base = conf->base_freq / 25000;
-                    ret = at86rf215_reg_write_8(h, base & 0xFF, REG_RF09_CCF0L);
-                    if (ret) {
-                        return ret;
-                    }
-                    ret = at86rf215_reg_write_8(h, base >> 8, REG_RF09_CCF0H);
-                    if (ret) {
-                        return ret;
-                    }
-                }
-            case AT86RF215_CM_FINE_RES_04:
-            case AT86RF215_CM_FINE_RES_09:
-                break;
-            default:
-                return -AT86RF215_INVAL_PARAM;
-        }
-    } else {
-        switch (conf->cm) {
-            case AT86RF215_CM_IEEE:
-                {
-                    ret = at86rf215_reg_write_8(h, spacing, REG_RF24_CS);
-                    if (ret) {
-                        return ret;
-                    }
-                    h->priv.radios[AT86RF215_RF24].cs_reg = spacing;
-                    h->priv.radios[AT86RF215_RF24].base_freq = conf->base_freq;
-
-                    /* Apply base frequency */
-                    if (conf->base_freq < 2400000000 || conf->base_freq > 2483500000) {
-                        return -AT86RF215_INVAL_PARAM;
-                    }
-                    /* At 2.4 GHz band the base frequency has a
-                     * 1.5 GHz offset
-                     */
-                    uint16_t base = (conf->base_freq - 1500000000) / 25000;
-                    ret = at86rf215_reg_write_8(h, base & 0xFF, REG_RF24_CCF0L);
-                    if (ret) {
-                        return ret;
-                    }
-                    ret = at86rf215_reg_write_8(h, base >> 8, REG_RF24_CCF0H);
-                    if (ret) {
-                        return ret;
-                    }
-                }
-            case AT86RF215_CM_FINE_RES_24:
-                break;
-            default:
-                return -AT86RF215_INVAL_PARAM;
-        }
+    case AT86RF215_CM_FINE_RES_04:
+    case AT86RF215_CM_FINE_RES_09:
+      break;
+    default:
+      return -AT86RF215_INVAL_PARAM;
     }
+  } else {
+    switch (conf->cm) {
+    case AT86RF215_CM_IEEE: {
+      ret = at86rf215_reg_write_8(h, spacing, REG_RF24_CS);
+      if (ret) {
+        return ret;
+      }
+      h->priv.radios[AT86RF215_RF24].cs_reg    = spacing;
+      h->priv.radios[AT86RF215_RF24].base_freq = conf->base_freq;
 
-    h->priv.radios[radio].cm = conf->cm;
-    h->priv.radios[radio].cs = conf->cs;
-
-    /* PLL loop bandwidth is applicable for the sub-1GHz radio only*/
-    if (radio == AT86RF215_RF09) {
-        switch (conf->lbw) {
-            case AT86RF215_PLL_LBW_DEFAULT:
-            case AT86RF215_PLL_LBW_SMALLER:
-            case AT86RF215_PLL_LBW_LARGER:
-                break;
-            default:
-                return -AT86RF215_INVAL_PARAM;
-        }
-        ret = at86rf215_reg_write_8(h, conf->lbw, REG_RF09_PLL);
-        if (ret) {
-            return ret;
-        }
+      /* Apply base frequency */
+      if (conf->base_freq < 2400000000 || conf->base_freq > 2483500000) {
+        return -AT86RF215_INVAL_PARAM;
+      }
+      /* At 2.4 GHz band the base frequency has a
+       * 1.5 GHz offset
+       */
+      uint16_t base = (conf->base_freq - 1500000000) / 25000;
+      ret           = at86rf215_reg_write_8(h, base & 0xFF, REG_RF24_CCF0L);
+      if (ret) {
+        return ret;
+      }
+      ret = at86rf215_reg_write_8(h, base >> 8, REG_RF24_CCF0H);
+      if (ret) {
+        return ret;
+      }
     }
-    h->priv.radios[radio].init = INIT_MAGIC_VAL;
-    return AT86RF215_OK;
+    case AT86RF215_CM_FINE_RES_24:
+      break;
+    default:
+      return -AT86RF215_INVAL_PARAM;
+    }
+  }
+
+  h->priv.radios[radio].cm = conf->cm;
+  h->priv.radios[radio].cs = conf->cs;
+
+  /* PLL loop bandwidth is applicable for the sub-1GHz radio only*/
+  if (radio == AT86RF215_RF09) {
+    switch (conf->lbw) {
+    case AT86RF215_PLL_LBW_DEFAULT:
+    case AT86RF215_PLL_LBW_SMALLER:
+    case AT86RF215_PLL_LBW_LARGER:
+      break;
+    default:
+      return -AT86RF215_INVAL_PARAM;
+    }
+    ret = at86rf215_reg_write_8(h, conf->lbw, REG_RF09_PLL);
+    if (ret) {
+      return ret;
+    }
+  }
+  h->priv.radios[radio].init = INIT_MAGIC_VAL;
+  return AT86RF215_OK;
 }
 
 /**
@@ -455,13 +480,15 @@ int at86rf215_radio_conf(struct at86rf215 *h, at86rf215_radio_t radio, const str
  * @param enable set to 1 to set the RSTN pin to high, 0 to set it to low
  * @return 0 on success or negative error code
  */
-__attribute__((weak)) int at86rf215_set_rstn(struct at86rf215 *h, uint8_t enable) {
-    if (enable) {
-        UHF_RST_HIGH();
-    } else {
-        UHF_RST_LOW();
-    }
-    return AT86RF215_OK;
+__attribute__((weak)) int
+at86rf215_set_rstn(struct at86rf215 *h, uint8_t enable)
+{
+  if (enable) {
+    UHF_RST_HIGH();
+  } else {
+    UHF_RST_LOW();
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -470,13 +497,15 @@ __attribute__((weak)) int at86rf215_set_rstn(struct at86rf215 *h, uint8_t enable
  * @param enable set to 1 to set the SELN pin to high, 0 to set it to low
  * @return 0 on success or negative error code
  */
-__attribute__((weak)) int at86rf215_set_seln(struct at86rf215 *h, uint8_t enable) {
-    if (enable) {
-        UHF_CS_HIGH();
-    } else {
-        UHF_CS_LOW();
-    }
-    return AT86RF215_OK;
+__attribute__((weak)) int
+at86rf215_set_seln(struct at86rf215 *h, uint8_t enable)
+{
+  if (enable) {
+    UHF_CS_HIGH();
+  } else {
+    UHF_CS_LOW();
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -484,9 +513,11 @@ __attribute__((weak)) int at86rf215_set_seln(struct at86rf215 *h, uint8_t enable
  * @param h the device handle
  * @param us the delay in microseconds
  */
-__attribute__((weak)) void at86rf215_delay_us(struct at86rf215 *h, uint32_t us) {
-    TickType_t ticks = pdMS_TO_TICKS((us + 999u) / 1000u);
-    vTaskDelay(ticks ? ticks : 1);
+__attribute__((weak)) void
+at86rf215_delay_us(struct at86rf215 *h, uint32_t us)
+{
+  TickType_t ticks = pdMS_TO_TICKS((us + 999u) / 1000u);
+  vTaskDelay(ticks ? ticks : 1);
 }
 
 /**
@@ -495,8 +526,10 @@ __attribute__((weak)) void at86rf215_delay_us(struct at86rf215 *h, uint32_t us) 
  *
  * @param h the device handle
  */
-__attribute__((weak)) size_t at86rf215_get_time_ms(struct at86rf215 *h) {
-    return (size_t)(xTaskGetTickCount() * portTICK_PERIOD_MS);
+__attribute__((weak)) size_t
+at86rf215_get_time_ms(struct at86rf215 *h)
+{
+  return (size_t)(xTaskGetTickCount() * portTICK_PERIOD_MS);
 }
 
 /**
@@ -508,27 +541,29 @@ __attribute__((weak)) size_t at86rf215_get_time_ms(struct at86rf215 *h) {
  * @param tx_len the number of the MISO bytes
  * @return 0 on success or negative error code
  */
-__attribute__((weak)) int at86rf215_spi_read(struct at86rf215 *h, uint8_t *out, const uint8_t *in, size_t tx_len, size_t rx_len) {
+__attribute__((weak)) int
+at86rf215_spi_read(struct at86rf215 *h, uint8_t *out, const uint8_t *in,
+                   size_t tx_len, size_t rx_len)
+{
+  memcpy(uhf_spi_tx_buffer, in, tx_len);
+  memset(uhf_spi_tx_buffer + tx_len, 0, rx_len - tx_len);
 
-    memcpy(uhf_spi_tx_buffer, in, tx_len);
-    memset(uhf_spi_tx_buffer + tx_len, 0, rx_len - tx_len);
+  struct spi_xfer xfer = {
+      .txbuf = uhf_spi_tx_buffer,
+      .rxbuf = out,
+      .size  = rx_len,
+  };
 
-    struct spi_xfer xfer = {
-        .txbuf = uhf_spi_tx_buffer,
-        .rxbuf = out,
-        .size = rx_len,
-    };
+  UHF_CS_LOW();
 
-    UHF_CS_LOW();
+  int32_t response = spi_m_sync_transfer(&SPI_UHF, &xfer);
 
-    int32_t response = spi_m_sync_transfer(&SPI_UHF, &xfer);
+  UHF_CS_HIGH();
 
-    UHF_CS_HIGH();
-
-    if (response != (int32_t)rx_len) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    return AT86RF215_OK;
+  if (response != (int32_t)rx_len) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -538,23 +573,25 @@ __attribute__((weak)) int at86rf215_spi_read(struct at86rf215 *h, uint8_t *out, 
  * @param len the size of the input buffer
  * @return 0 on success or negative error code
  */
-__attribute__((weak)) int at86rf215_spi_write(struct at86rf215 *h, const uint8_t *in, size_t len) {
-    struct spi_xfer xfer = {
-        .txbuf = (uint8_t *)in,
-        .rxbuf = uhf_spi_rx_buffer, // Unused
-        .size = len,
-    };
+__attribute__((weak)) int
+at86rf215_spi_write(struct at86rf215 *h, const uint8_t *in, size_t len)
+{
+  struct spi_xfer xfer = {
+      .txbuf = (uint8_t *)in,
+      .rxbuf = uhf_spi_rx_buffer, // Unused
+      .size  = len,
+  };
 
-    UHF_CS_LOW();
+  UHF_CS_LOW();
 
-    int32_t response = spi_m_sync_transfer(&SPI_UHF, &xfer);
+  int32_t response = spi_m_sync_transfer(&SPI_UHF, &xfer);
 
-    UHF_CS_HIGH();
+  UHF_CS_HIGH();
 
-    if (response != (int32_t)len) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    return AT86RF215_OK;
+  if (response != (int32_t)len) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -568,29 +605,31 @@ __attribute__((weak)) int at86rf215_spi_write(struct at86rf215 *h, const uint8_t
  * @param reg the register to read
  * @return 0 on success or negative error code
  */
-int at86rf215_reg_read_8(struct at86rf215 *h, uint8_t *out, uint16_t reg) {
-    if (!out) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    int ret = 0;
-    ret = at86rf215_set_seln(h, 0);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_reg_read_8(struct at86rf215 *h, uint8_t *out, uint16_t reg)
+{
+  if (!out) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  int ret = 0;
+  ret     = at86rf215_set_seln(h, 0);
+  if (ret) {
+    return ret;
+  }
 
-    at86rf215_irq_enable(h, 0);
-    /* Construct properly the MOSI buffer */
-    uint8_t mosi[2] = {(reg >> 8) & 0x3F, reg & 0xFF};
-    uint8_t miso[3] = {0x0, 0x0, 0x0};
-    ret = at86rf215_spi_read(h, miso, mosi, 2, 3);
-    if (ret) {
-        at86rf215_irq_enable(h, 1);
-        at86rf215_set_seln(h, 1);
-        return ret;
-    }
-    *out = miso[2];
+  at86rf215_irq_enable(h, 0);
+  /* Construct properly the MOSI buffer */
+  uint8_t mosi[2] = {(reg >> 8) & 0x3F, reg & 0xFF};
+  uint8_t miso[3] = {0x0, 0x0, 0x0};
+  ret             = at86rf215_spi_read(h, miso, mosi, 2, 3);
+  if (ret) {
     at86rf215_irq_enable(h, 1);
-    return at86rf215_set_seln(h, 1);
+    at86rf215_set_seln(h, 1);
+    return ret;
+  }
+  *out = miso[2];
+  at86rf215_irq_enable(h, 1);
+  return at86rf215_set_seln(h, 1);
 }
 
 /**
@@ -605,28 +644,30 @@ int at86rf215_reg_read_8(struct at86rf215 *h, uint8_t *out, uint16_t reg) {
  * @param reg the register to read
  * @return 0 on success or negative error code
  */
-int at86rf215_reg_read_32(struct at86rf215 *h, uint32_t *out, uint16_t reg) {
-    if (!out) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    int ret = 0;
-    ret = at86rf215_set_seln(h, 0);
-    if (ret) {
-        return ret;
-    }
-    at86rf215_irq_enable(h, 0);
-    /* Construct properly the MOSI buffer */
-    uint8_t mosi[2] = {(reg >> 8) & 0x3F, reg & 0xFF};
-    uint8_t miso[6] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    ret = at86rf215_spi_read(h, miso, mosi, 2, 6);
-    if (ret) {
-        at86rf215_set_seln(h, 1);
-        at86rf215_irq_enable(h, 1);
-        return ret;
-    }
-    *out = (miso[2] << 24) | (miso[3] << 16) | (miso[4] << 8) | miso[5];
+int
+at86rf215_reg_read_32(struct at86rf215 *h, uint32_t *out, uint16_t reg)
+{
+  if (!out) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  int ret = 0;
+  ret     = at86rf215_set_seln(h, 0);
+  if (ret) {
+    return ret;
+  }
+  at86rf215_irq_enable(h, 0);
+  /* Construct properly the MOSI buffer */
+  uint8_t mosi[2] = {(reg >> 8) & 0x3F, reg & 0xFF};
+  uint8_t miso[6] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+  ret             = at86rf215_spi_read(h, miso, mosi, 2, 6);
+  if (ret) {
+    at86rf215_set_seln(h, 1);
     at86rf215_irq_enable(h, 1);
-    return at86rf215_set_seln(h, 1);
+    return ret;
+  }
+  *out = (miso[2] << 24) | (miso[3] << 16) | (miso[4] << 8) | miso[5];
+  at86rf215_irq_enable(h, 1);
+  return at86rf215_set_seln(h, 1);
 }
 
 /**
@@ -641,23 +682,25 @@ int at86rf215_reg_read_32(struct at86rf215 *h, uint32_t *out, uint16_t reg) {
  * @param reg the register to write
  * @return 0 on success or negative error code
  */
-int at86rf215_reg_write_8(struct at86rf215 *h, const uint8_t in, uint16_t reg) {
-    int ret = 0;
-    ret = at86rf215_set_seln(h, 0);
-    if (ret) {
-        return ret;
-    }
-    at86rf215_irq_enable(h, 0);
-    /* Construct properly the MOSI buffer */
-    uint8_t mosi[3] = {(reg >> 8) | 0x80, reg & 0xFF, in};
-    ret = at86rf215_spi_write(h, mosi, 3);
-    if (ret) {
-        at86rf215_set_seln(h, 1);
-        at86rf215_irq_enable(h, 1);
-        return ret;
-    }
+int
+at86rf215_reg_write_8(struct at86rf215 *h, const uint8_t in, uint16_t reg)
+{
+  int ret = 0;
+  ret     = at86rf215_set_seln(h, 0);
+  if (ret) {
+    return ret;
+  }
+  at86rf215_irq_enable(h, 0);
+  /* Construct properly the MOSI buffer */
+  uint8_t mosi[3] = {(reg >> 8) | 0x80, reg & 0xFF, in};
+  ret             = at86rf215_spi_write(h, mosi, 3);
+  if (ret) {
+    at86rf215_set_seln(h, 1);
     at86rf215_irq_enable(h, 1);
-    return at86rf215_set_seln(h, 1);
+    return ret;
+  }
+  at86rf215_irq_enable(h, 1);
+  return at86rf215_set_seln(h, 1);
 }
 
 /**
@@ -673,23 +716,25 @@ int at86rf215_reg_write_8(struct at86rf215 *h, const uint8_t in, uint16_t reg) {
  * @param reg the register to write
  * @return 0 on success or negative error code
  */
-int at86rf215_reg_write_16(struct at86rf215 *h, const uint16_t in, uint16_t reg) {
-    int ret = 0;
-    ret = at86rf215_set_seln(h, 0);
-    if (ret) {
-        return ret;
-    }
-    at86rf215_irq_enable(h, 0);
-    /* Construct properly the MOSI buffer */
-    uint8_t mosi[4] = {(reg >> 8) | 0x80, reg & 0xFF, in >> 8, in & 0xFF};
-    ret = at86rf215_spi_write(h, mosi, 4);
-    if (ret) {
-        at86rf215_set_seln(h, 1);
-        at86rf215_irq_enable(h, 1);
-        return ret;
-    }
+int
+at86rf215_reg_write_16(struct at86rf215 *h, const uint16_t in, uint16_t reg)
+{
+  int ret = 0;
+  ret     = at86rf215_set_seln(h, 0);
+  if (ret) {
+    return ret;
+  }
+  at86rf215_irq_enable(h, 0);
+  /* Construct properly the MOSI buffer */
+  uint8_t mosi[4] = {(reg >> 8) | 0x80, reg & 0xFF, in >> 8, in & 0xFF};
+  ret             = at86rf215_spi_write(h, mosi, 4);
+  if (ret) {
+    at86rf215_set_seln(h, 1);
     at86rf215_irq_enable(h, 1);
-    return at86rf215_set_seln(h, 1);
+    return ret;
+  }
+  at86rf215_irq_enable(h, 1);
+  return at86rf215_set_seln(h, 1);
 }
 
 /**
@@ -699,45 +744,48 @@ int at86rf215_reg_write_16(struct at86rf215 *h, const uint16_t in, uint16_t reg)
  * @param radio the radio front-end to query its state
  * @return 0 on success or negative error code
  */
-int at86rf215_get_state(struct at86rf215 *h, at86rf215_rf_state_t *state, at86rf215_radio_t radio) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!state) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint8_t val = 0;
-    uint16_t reg = 0;
-    switch (radio) {
-        case AT86RF215_RF24:
-            reg = REG_RF24_STATE;
-            break;
-        case AT86RF215_RF09:
-            reg = REG_RF09_STATE;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    /* Sanity check on the returned value */
-    val &= 0x7;
-    switch (val) {
-        case AT86RF215_STATE_RF_TRXOFF:
-        case AT86RF215_STATE_RF_TXPREP:
-        case AT86RF215_STATE_RF_TX:
-        case AT86RF215_STATE_RF_RX:
-        case AT86RF215_STATE_RF_TRANSITION:
-        case AT86RF215_STATE_RF_RESET:
-            *state = (at86rf215_rf_state_t)val;
-            break;
-        default:
-            return -AT86RF215_INVAL_VAL;
-    }
-    return AT86RF215_OK;
+int
+at86rf215_get_state(struct at86rf215 *h, at86rf215_rf_state_t *state,
+                    at86rf215_radio_t radio)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!state) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint8_t  val = 0;
+  uint16_t reg = 0;
+  switch (radio) {
+  case AT86RF215_RF24:
+    reg = REG_RF24_STATE;
+    break;
+  case AT86RF215_RF09:
+    reg = REG_RF09_STATE;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  ret = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  /* Sanity check on the returned value */
+  val &= 0x7;
+  switch (val) {
+  case AT86RF215_STATE_RF_TRXOFF:
+  case AT86RF215_STATE_RF_TXPREP:
+  case AT86RF215_STATE_RF_TX:
+  case AT86RF215_STATE_RF_RX:
+  case AT86RF215_STATE_RF_TRANSITION:
+  case AT86RF215_STATE_RF_RESET:
+    *state = (at86rf215_rf_state_t)val;
+    break;
+  default:
+    return -AT86RF215_INVAL_VAL;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -747,35 +795,38 @@ int at86rf215_get_state(struct at86rf215 *h, at86rf215_rf_state_t *state, at86rf
  * @param radio the radio front-end
  * @return 0 on success or negative error code
  */
-int at86rf215_set_cmd(struct at86rf215 *h, at86rf215_rf_cmd_t cmd, at86rf215_radio_t radio) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    switch (cmd) {
-        case AT86RF215_CMD_RF_NOP:
-        case AT86RF215_CMD_RF_SLEEP:
-        case AT86RF215_CMD_RF_TRXOFF:
-        case AT86RF215_CMD_RF_TXPREP:
-        case AT86RF215_CMD_RF_TX:
-        case AT86RF215_CMD_RF_RX:
-        case AT86RF215_CMD_RF_RESET:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    uint16_t reg = 0;
-    switch (radio) {
-        case AT86RF215_RF09:
-            reg = REG_RF09_CMD;
-            break;
-        case AT86RF215_RF24:
-            reg = REG_RF24_CMD;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    return at86rf215_reg_write_8(h, cmd, reg);
+int
+at86rf215_set_cmd(struct at86rf215 *h, at86rf215_rf_cmd_t cmd,
+                  at86rf215_radio_t radio)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  switch (cmd) {
+  case AT86RF215_CMD_RF_NOP:
+  case AT86RF215_CMD_RF_SLEEP:
+  case AT86RF215_CMD_RF_TRXOFF:
+  case AT86RF215_CMD_RF_TXPREP:
+  case AT86RF215_CMD_RF_TX:
+  case AT86RF215_CMD_RF_RX:
+  case AT86RF215_CMD_RF_RESET:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint16_t reg = 0;
+  switch (radio) {
+  case AT86RF215_RF09:
+    reg = REG_RF09_CMD;
+    break;
+  case AT86RF215_RF24:
+    reg = REG_RF24_CMD;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  return at86rf215_reg_write_8(h, cmd, reg);
 }
 
 /**
@@ -787,20 +838,23 @@ int at86rf215_set_cmd(struct at86rf215 *h, at86rf215_rf_cmd_t cmd, at86rf215_rad
  * @param timeout timeout in miliseconds
  * @return int 0 on success or negative error code
  */
-int at86rf215_set_trxoff(struct at86rf215 *h, at86rf215_radio_t radio, size_t timeout_ms) {
-    size_t deadline = at86rf215_get_time_ms(h) + timeout_ms;
-    at86rf215_rf_state_t state = AT86RF215_STATE_RF_TRANSITION;
+int
+at86rf215_set_trxoff(struct at86rf215 *h, at86rf215_radio_t radio,
+                     size_t timeout_ms)
+{
+  size_t               deadline = at86rf215_get_time_ms(h) + timeout_ms;
+  at86rf215_rf_state_t state    = AT86RF215_STATE_RF_TRANSITION;
 
-    while (state != AT86RF215_STATE_RF_TRXOFF) {
-        at86rf215_delay_us(h, 100);
-        if (at86rf215_get_time_ms(h) > deadline) {
-            return -AT86RF215_TIMEOUT;
-        }
-        at86rf215_set_cmd(h, AT86RF215_CMD_RF_TRXOFF, radio);
-        at86rf215_delay_us(h, 100);
-        at86rf215_get_state(h, &state, radio);
+  while (state != AT86RF215_STATE_RF_TRXOFF) {
+    at86rf215_delay_us(h, 100);
+    if (at86rf215_get_time_ms(h) > deadline) {
+      return -AT86RF215_TIMEOUT;
     }
-    return AT86RF215_OK;
+    at86rf215_set_cmd(h, AT86RF215_CMD_RF_TRXOFF, radio);
+    at86rf215_delay_us(h, 100);
+    at86rf215_get_state(h, &state, radio);
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -811,24 +865,26 @@ int at86rf215_set_trxoff(struct at86rf215 *h, at86rf215_radio_t radio, size_t ti
  * @param mode the chip mode
  * @return 0 on success or negative error code
  */
-int at86rf215_set_mode(struct at86rf215 *h, at86rf215_chpm_t mode) {
-    int ret = supports_mode(h, mode);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_set_mode(struct at86rf215 *h, at86rf215_chpm_t mode)
+{
+  int ret = supports_mode(h, mode);
+  if (ret) {
+    return ret;
+  }
 
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, REG_RF_IQIFC1);
-    if (ret) {
-        return ret;
-    }
-    val = (val & 0x3) | (mode << 4);
-    ret = at86rf215_reg_write_8(h, val, REG_RF_IQIFC1);
-    if (ret) {
-        return ret;
-    }
-    h->priv.chpm = mode;
-    return AT86RF215_OK;
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, REG_RF_IQIFC1);
+  if (ret) {
+    return ret;
+  }
+  val = (val & 0x3) | (mode << 4);
+  ret = at86rf215_reg_write_8(h, val, REG_RF_IQIFC1);
+  if (ret) {
+    return ret;
+  }
+  h->priv.chpm = mode;
+  return AT86RF215_OK;
 }
 
 /**
@@ -841,8 +897,10 @@ int at86rf215_set_mode(struct at86rf215 *h, at86rf215_chpm_t mode) {
  * @param radio the transceiver to reset
  * @return 0 on success or negative error code
  */
-int at86rf215_transceiver_reset(struct at86rf215 *h, at86rf215_radio_t radio) {
-    return at86rf215_set_cmd(h, AT86RF215_CMD_RF_RESET, radio);
+int
+at86rf215_transceiver_reset(struct at86rf215 *h, at86rf215_radio_t radio)
+{
+  return at86rf215_set_cmd(h, AT86RF215_CMD_RF_RESET, radio);
 }
 
 /**
@@ -853,23 +911,26 @@ int at86rf215_transceiver_reset(struct at86rf215 *h, at86rf215_radio_t radio) {
  * @param mask the activation mask
  * @return 0 on success or negative error code
  */
-int at86rf215_set_bbc_irq_mask(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t mask) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    uint16_t reg = 0x0;
-    switch (radio) {
-        case AT86RF215_RF09:
-            reg = REG_BBC0_IRQM;
-            break;
-        case AT86RF215_RF24:
-            reg = REG_BBC1_IRQM;
-            break;
-        default:
-            return -AT86RF215_NOT_SUPPORTED;
-    }
-    return at86rf215_reg_write_8(h, mask, reg);
+int
+at86rf215_set_bbc_irq_mask(struct at86rf215 *h, at86rf215_radio_t radio,
+                           uint8_t mask)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  uint16_t reg = 0x0;
+  switch (radio) {
+  case AT86RF215_RF09:
+    reg = REG_BBC0_IRQM;
+    break;
+  case AT86RF215_RF24:
+    reg = REG_BBC1_IRQM;
+    break;
+  default:
+    return -AT86RF215_NOT_SUPPORTED;
+  }
+  return at86rf215_reg_write_8(h, mask, reg);
 }
 
 /**
@@ -880,18 +941,21 @@ int at86rf215_set_bbc_irq_mask(struct at86rf215 *h, at86rf215_radio_t radio, uin
  * @param mask the activation mask
  * @return 0 on success or negative error code
  */
-int at86rf215_set_radio_irq_mask(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t mask) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    uint16_t reg = 0x0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_IRQM;
-    } else {
-        reg = REG_RF24_IRQM;
-    }
-    return at86rf215_reg_write_8(h, mask, reg);
+int
+at86rf215_set_radio_irq_mask(struct at86rf215 *h, at86rf215_radio_t radio,
+                             uint8_t mask)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  uint16_t reg = 0x0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_IRQM;
+  } else {
+    reg = REG_RF24_IRQM;
+  }
+  return at86rf215_reg_write_8(h, mask, reg);
 }
 
 /**
@@ -900,23 +964,25 @@ int at86rf215_set_radio_irq_mask(struct at86rf215 *h, at86rf215_radio_t radio, u
  * @param lpf the low pass filter setting
  * @return true if the setting is valid, false otherwise
  */
-static bool is_lpf_valid(at86rf215_lpfcut_t lpf) {
-    switch (lpf) {
-        case AT86RF215_RF_FLC80KHZ:
-        case AT86RF215_RF_FLC100KHZ:
-        case AT86RF215_RF_FLC125KHZ:
-        case AT86RF215_RF_FLC160KHZ:
-        case AT86RF215_RF_FLC200KHZ:
-        case AT86RF215_RF_FLC250KHZ:
-        case AT86RF215_RF_FLC315KHZ:
-        case AT86RF215_RF_FLC400KHZ:
-        case AT86RF215_RF_FLC500KHZ:
-        case AT86RF215_RF_FLC624KHZ:
-        case AT86RF215_RF_FLC800KHZ:
-        case AT86RF215_RF_FLC1000KHZ:
-            return 1;
-    }
-    return 0;
+static bool
+is_lpf_valid(at86rf215_lpfcut_t lpf)
+{
+  switch (lpf) {
+  case AT86RF215_RF_FLC80KHZ:
+  case AT86RF215_RF_FLC100KHZ:
+  case AT86RF215_RF_FLC125KHZ:
+  case AT86RF215_RF_FLC160KHZ:
+  case AT86RF215_RF_FLC200KHZ:
+  case AT86RF215_RF_FLC250KHZ:
+  case AT86RF215_RF_FLC315KHZ:
+  case AT86RF215_RF_FLC400KHZ:
+  case AT86RF215_RF_FLC500KHZ:
+  case AT86RF215_RF_FLC624KHZ:
+  case AT86RF215_RF_FLC800KHZ:
+  case AT86RF215_RF_FLC1000KHZ:
+    return 1;
+  }
+  return 0;
 }
 
 /**
@@ -925,15 +991,17 @@ static bool is_lpf_valid(at86rf215_lpfcut_t lpf) {
  * @param paramp the power amplifier setting
  * @return true if the setting is valid, false otherwise
  */
-static bool is_paramp_valid(at86rf215_paramp_t paramp) {
-    switch (paramp) {
-        case AT86RF215_RF_PARAMP4U:
-        case AT86RF215_RF_PARAMP8U:
-        case AT86RF215_RF_PARAMP16U:
-        case AT86RF215_RF_PARAMP32U:
-            return 1;
-    }
-    return 0;
+static bool
+is_paramp_valid(at86rf215_paramp_t paramp)
+{
+  switch (paramp) {
+  case AT86RF215_RF_PARAMP4U:
+  case AT86RF215_RF_PARAMP8U:
+  case AT86RF215_RF_PARAMP16U:
+  case AT86RF215_RF_PARAMP32U:
+    return 1;
+  }
+  return 0;
 }
 
 /**
@@ -944,21 +1012,24 @@ static bool is_paramp_valid(at86rf215_paramp_t paramp) {
  * @param lpf LPF setting
  * @return 0 on success or negative error code
  */
-int at86rf215_set_txcutc(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_paramp_t paramp, at86rf215_lpfcut_t lpf) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!is_lpf_valid(lpf) || !is_paramp_valid(paramp)) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint16_t reg = 0x0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_TXCUTC;
-    } else {
-        reg = REG_RF24_TXCUTC;
-    }
-    return at86rf215_reg_write_8(h, paramp << 6 | lpf, reg);
+int
+at86rf215_set_txcutc(struct at86rf215 *h, at86rf215_radio_t radio,
+                     at86rf215_paramp_t paramp, at86rf215_lpfcut_t lpf)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!is_lpf_valid(lpf) || !is_paramp_valid(paramp)) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint16_t reg = 0x0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_TXCUTC;
+  } else {
+    reg = REG_RF24_TXCUTC;
+  }
+  return at86rf215_reg_write_8(h, paramp << 6 | lpf, reg);
 }
 
 /**
@@ -970,40 +1041,43 @@ int at86rf215_set_txcutc(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215
  * @param sr the sampling rate setting
  * @return 0 on success or negative error code
  */
-static int set_txdfe(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_rcut_t rcut, uint8_t dm, at86rf215_sr_t sr) {
-    uint16_t reg = 0x0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_TXDFE;
-    } else {
-        reg = REG_RF24_TXDFE;
-    }
-    switch (sr) {
-        case AT86RF215_SR_4000KHZ:
-        case AT86RF215_SR_2000KHZ:
-        case AT86RF215_SR_1333KHZ:
-        case AT86RF215_SR_1000KHZ:
-        case AT86RF215_SR_800KHZ:
-        case AT86RF215_SR_666KHZ:
-        case AT86RF215_SR_500KHZ:
-        case AT86RF215_SR_400KHZ:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+static int
+set_txdfe(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_rcut_t rcut,
+          uint8_t dm, at86rf215_sr_t sr)
+{
+  uint16_t reg = 0x0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_TXDFE;
+  } else {
+    reg = REG_RF24_TXDFE;
+  }
+  switch (sr) {
+  case AT86RF215_SR_4000KHZ:
+  case AT86RF215_SR_2000KHZ:
+  case AT86RF215_SR_1333KHZ:
+  case AT86RF215_SR_1000KHZ:
+  case AT86RF215_SR_800KHZ:
+  case AT86RF215_SR_666KHZ:
+  case AT86RF215_SR_500KHZ:
+  case AT86RF215_SR_400KHZ:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    switch (rcut) {
-        case AT86RF215_RCUT_25FS2:
-        case AT86RF215_RCUT_37FS2:
-        case AT86RF215_RCUT_50FS2:
-        case AT86RF215_RCUT_75FS2:
-        case AT86RF215_RCUT_100FS2:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+  switch (rcut) {
+  case AT86RF215_RCUT_25FS2:
+  case AT86RF215_RCUT_37FS2:
+  case AT86RF215_RCUT_50FS2:
+  case AT86RF215_RCUT_75FS2:
+  case AT86RF215_RCUT_100FS2:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    const uint8_t val = (rcut << 5) | ((dm & 0x1) << 4) | sr;
-    return at86rf215_reg_write_8(h, val, reg);
+  const uint8_t val = (rcut << 5) | ((dm & 0x1) << 4) | sr;
+  return at86rf215_reg_write_8(h, val, reg);
 }
 
 /**
@@ -1014,40 +1088,43 @@ static int set_txdfe(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_rcu
  * @param sr the sampling rate setting
  * @return 0 on success or negative error code
  */
-static int set_rxdfe(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_rcut_t rcut, at86rf215_sr_t sr) {
-    uint16_t reg = 0x0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_RXDFE;
-    } else {
-        reg = REG_RF24_RXDFE;
-    }
-    switch (sr) {
-        case AT86RF215_SR_4000KHZ:
-        case AT86RF215_SR_2000KHZ:
-        case AT86RF215_SR_1333KHZ:
-        case AT86RF215_SR_1000KHZ:
-        case AT86RF215_SR_800KHZ:
-        case AT86RF215_SR_666KHZ:
-        case AT86RF215_SR_500KHZ:
-        case AT86RF215_SR_400KHZ:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+static int
+set_rxdfe(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_rcut_t rcut,
+          at86rf215_sr_t sr)
+{
+  uint16_t reg = 0x0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_RXDFE;
+  } else {
+    reg = REG_RF24_RXDFE;
+  }
+  switch (sr) {
+  case AT86RF215_SR_4000KHZ:
+  case AT86RF215_SR_2000KHZ:
+  case AT86RF215_SR_1333KHZ:
+  case AT86RF215_SR_1000KHZ:
+  case AT86RF215_SR_800KHZ:
+  case AT86RF215_SR_666KHZ:
+  case AT86RF215_SR_500KHZ:
+  case AT86RF215_SR_400KHZ:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    switch (rcut) {
-        case AT86RF215_RCUT_25FS2:
-        case AT86RF215_RCUT_37FS2:
-        case AT86RF215_RCUT_50FS2:
-        case AT86RF215_RCUT_75FS2:
-        case AT86RF215_RCUT_100FS2:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+  switch (rcut) {
+  case AT86RF215_RCUT_25FS2:
+  case AT86RF215_RCUT_37FS2:
+  case AT86RF215_RCUT_50FS2:
+  case AT86RF215_RCUT_75FS2:
+  case AT86RF215_RCUT_100FS2:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    const uint8_t val = (rcut << 5) | sr;
-    return at86rf215_reg_write_8(h, val, reg);
+  const uint8_t val = (rcut << 5) | sr;
+  return at86rf215_reg_write_8(h, val, reg);
 }
 /**
  * Configures the RX digital frontend cuttoff frequency using the RXDFE
@@ -1058,24 +1135,27 @@ static int set_rxdfe(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_rcu
  * @param rcut RX filter relative to the cut-off frequency
  * @return 0 on success or negative error code
  */
-int at86rf215_set_rx_rcut(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t rcut) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    uint16_t reg = 0x0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_RXDFE;
-    } else {
-        reg = REG_RF24_RXDFE;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    val &= 0x1F;
-    return at86rf215_reg_write_8(h, ((rcut & 0x7) << 5) | val, reg);
+int
+at86rf215_set_rx_rcut(struct at86rf215 *h, at86rf215_radio_t radio,
+                      uint8_t rcut)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  uint16_t reg = 0x0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_RXDFE;
+  } else {
+    reg = REG_RF24_RXDFE;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  val &= 0x1F;
+  return at86rf215_reg_write_8(h, ((rcut & 0x7) << 5) | val, reg);
 }
 
 /**
@@ -1086,31 +1166,34 @@ int at86rf215_set_rx_rcut(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t 
  * @param power the output PA (0-31). 1-dB step resolution
  * @return 0 on success or negative error code
  */
-int at86rf215_set_pac(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_pacur_t pacur, uint8_t power) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    switch (pacur) {
-        case AT86RF215_PACUR_22mA_RED:
-        case AT86RF215_PACUR_18mA_RED:
-        case AT86RF215_PACUR_11mA_RED:
-        case AT86RF215_PACUR_NO_RED:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    if (power > 31) {
-        power = 31;
-    }
+int
+at86rf215_set_pac(struct at86rf215 *h, at86rf215_radio_t radio,
+                  at86rf215_pacur_t pacur, uint8_t power)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  switch (pacur) {
+  case AT86RF215_PACUR_22mA_RED:
+  case AT86RF215_PACUR_18mA_RED:
+  case AT86RF215_PACUR_11mA_RED:
+  case AT86RF215_PACUR_NO_RED:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  if (power > 31) {
+    power = 31;
+  }
 
-    uint16_t reg = 0x0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_PAC;
-    } else {
-        reg = REG_RF24_PAC;
-    }
-    return at86rf215_reg_write_8(h, (pacur << 5) | power, reg);
+  uint16_t reg = 0x0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_PAC;
+  } else {
+    reg = REG_RF24_PAC;
+  }
+  return at86rf215_reg_write_8(h, (pacur << 5) | power, reg);
 }
 
 /**
@@ -1122,38 +1205,45 @@ int at86rf215_set_pac(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_pa
  * @param channel channel index
  * @return 0 on success or negative error code
  */
-int at86rf215_set_channel(struct at86rf215 *h, at86rf215_radio_t radio, uint16_t channel) {
-    int ret = radio_ready(h, radio);
+int
+at86rf215_set_channel(struct at86rf215 *h, at86rf215_radio_t radio,
+                      uint16_t channel)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (channel > 0x1F) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  /* The radio should be in IEEE channel mode to set a channel */
+  if (h->priv.radios[radio].cm != AT86RF215_CM_IEEE) {
+    return -AT86RF215_INVAL_CONF;
+  }
+  if (radio == AT86RF215_RF09) {
+    ret = at86rf215_reg_write_8(h, channel & 0xFF, REG_RF09_CNL);
     if (ret) {
-        return ret;
+      return ret;
     }
-    if (channel > 0x1F) {
-        return -AT86RF215_INVAL_PARAM;
+    ret = at86rf215_reg_write_8(
+        h, (h->priv.radios[radio].cm << 6) | ((channel >> 8) & 0x1),
+        REG_RF09_CNM);
+    if (ret) {
+      return ret;
     }
-    /* The radio should be in IEEE channel mode to set a channel */
-    if (h->priv.radios[radio].cm != AT86RF215_CM_IEEE) {
-        return -AT86RF215_INVAL_CONF;
+  } else {
+    ret = at86rf215_reg_write_8(h, channel & 0xFF, REG_RF24_CNL);
+    if (ret) {
+      return ret;
     }
-    if (radio == AT86RF215_RF09) {
-        ret = at86rf215_reg_write_8(h, channel & 0xFF, REG_RF09_CNL);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, (h->priv.radios[radio].cm << 6) | ((channel >> 8) & 0x1), REG_RF09_CNM);
-        if (ret) {
-            return ret;
-        }
-    } else {
-        ret = at86rf215_reg_write_8(h, channel & 0xFF, REG_RF24_CNL);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, (h->priv.radios[radio].cm << 6) | ((channel >> 8) & 0x1), REG_RF24_CNM);
-        if (ret) {
-            return ret;
-        }
+    ret = at86rf215_reg_write_8(
+        h, (h->priv.radios[radio].cm << 6) | ((channel >> 8) & 0x1),
+        REG_RF24_CNM);
+    if (ret) {
+      return ret;
     }
-    return AT86RF215_OK;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -1166,73 +1256,75 @@ int at86rf215_set_channel(struct at86rf215 *h, at86rf215_radio_t radio, uint16_t
  * @param freq the center frequency in Hz
  * @return 0 on success or negative error code
  */
-int at86rf215_set_freq(struct at86rf215 *h, at86rf215_radio_t radio, uint32_t freq) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
-    /* The radio should be in fine freq mode to set the frequency */
-    if (radio == AT86RF215_RF09) {
-        uint32_t x = 0;
-        if (h->priv.radios[AT86RF215_RF09].cm == AT86RF215_CM_FINE_RES_04) {
-            if (freq < 389500000 || freq > 510000000) {
-                return -AT86RF215_INVAL_PARAM;
-            }
-            x = ((freq - 377e6) * (1 << 16)) / 6.5e6;
-        } else if (h->priv.radios[AT86RF215_RF09].cm == AT86RF215_CM_FINE_RES_09) {
-            if (freq < 779000000 || freq > 1020000000) {
-                return -AT86RF215_INVAL_PARAM;
-            }
-            x = ((freq - 754e6) * (1 << 16)) / 13e6;
-        } else {
-            return -AT86RF215_INVAL_CONF;
-        }
-        /* Apply the frequency setting */
-        ret = at86rf215_reg_write_8(h, (x >> 16) & 0xFF, REG_RF09_CCF0H);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, (x >> 8) & 0xFF, REG_RF09_CCF0L);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, x & 0xFF, REG_RF09_CNL);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, h->priv.radios[radio].cm << 6, REG_RF09_CNM);
-        if (ret) {
-            return ret;
-        }
+int
+at86rf215_set_freq(struct at86rf215 *h, at86rf215_radio_t radio, uint32_t freq)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  /* The radio should be in fine freq mode to set the frequency */
+  if (radio == AT86RF215_RF09) {
+    uint32_t x = 0;
+    if (h->priv.radios[AT86RF215_RF09].cm == AT86RF215_CM_FINE_RES_04) {
+      if (freq < 389500000 || freq > 510000000) {
+        return -AT86RF215_INVAL_PARAM;
+      }
+      x = ((freq - 377e6) * (1 << 16)) / 6.5e6;
+    } else if (h->priv.radios[AT86RF215_RF09].cm == AT86RF215_CM_FINE_RES_09) {
+      if (freq < 779000000 || freq > 1020000000) {
+        return -AT86RF215_INVAL_PARAM;
+      }
+      x = ((freq - 754e6) * (1 << 16)) / 13e6;
     } else {
-        uint32_t x = 0;
-        if (h->priv.radios[AT86RF215_RF24].cm == AT86RF215_CM_FINE_RES_24) {
-            if (freq < 2400000000 || freq > 2486000000) {
-                return -AT86RF215_INVAL_PARAM;
-            }
-            x = ((freq - 2366e6) * (1 << 16)) / 26e6;
-        } else {
-            return -AT86RF215_INVAL_CONF;
-        }
-        /* Apply the frequency setting */
-        ret = at86rf215_reg_write_8(h, (x >> 16) & 0xFF, REG_RF24_CCF0H);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, (x >> 8) & 0xFF, REG_RF24_CCF0L);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, x & 0xFF, REG_RF24_CNL);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, h->priv.radios[radio].cm << 6, REG_RF24_CNM);
-        if (ret) {
-            return ret;
-        }
+      return -AT86RF215_INVAL_CONF;
     }
-    return AT86RF215_OK;
+    /* Apply the frequency setting */
+    ret = at86rf215_reg_write_8(h, (x >> 16) & 0xFF, REG_RF09_CCF0H);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, (x >> 8) & 0xFF, REG_RF09_CCF0L);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, x & 0xFF, REG_RF09_CNL);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, h->priv.radios[radio].cm << 6, REG_RF09_CNM);
+    if (ret) {
+      return ret;
+    }
+  } else {
+    uint32_t x = 0;
+    if (h->priv.radios[AT86RF215_RF24].cm == AT86RF215_CM_FINE_RES_24) {
+      if (freq < 2400000000 || freq > 2486000000) {
+        return -AT86RF215_INVAL_PARAM;
+      }
+      x = ((freq - 2366e6) * (1 << 16)) / 26e6;
+    } else {
+      return -AT86RF215_INVAL_CONF;
+    }
+    /* Apply the frequency setting */
+    ret = at86rf215_reg_write_8(h, (x >> 16) & 0xFF, REG_RF24_CCF0H);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, (x >> 8) & 0xFF, REG_RF24_CCF0L);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, x & 0xFF, REG_RF24_CNL);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, h->priv.radios[radio].cm << 6, REG_RF24_CNM);
+    if (ret) {
+      return ret;
+    }
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -1246,9 +1338,11 @@ int at86rf215_set_freq(struct at86rf215 *h, at86rf215_radio_t radio, uint32_t fr
  * @param enable 1 to enable, 0 to disable
  * @return 0 on success or negative error code
  */
-__attribute__((weak)) int at86rf215_irq_enable(struct at86rf215 *h, uint8_t enable) {
-    (void)enable;
-    return AT86RF215_OK;
+__attribute__((weak)) int
+at86rf215_irq_enable(struct at86rf215 *h, uint8_t enable)
+{
+  (void)enable;
+  return AT86RF215_OK;
 }
 
 /**
@@ -1258,24 +1352,27 @@ __attribute__((weak)) int at86rf215_irq_enable(struct at86rf215 *h, uint8_t enab
  * @param radio the RF frontend
  * @return 0 on success or negative error code
  */
-int at86rf215_get_pll_ls(struct at86rf215 *h, at86rf215_pll_ls_t *status, at86rf215_radio_t radio) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_PLL;
-    } else {
-        reg = REG_RF24_PLL;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    *status = (at86rf215_pll_ls_t)((val >> 1) & 0x1);
-    return AT86RF215_OK;
+int
+at86rf215_get_pll_ls(struct at86rf215 *h, at86rf215_pll_ls_t *status,
+                     at86rf215_radio_t radio)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_PLL;
+  } else {
+    reg = REG_RF24_PLL;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  *status = (at86rf215_pll_ls_t)((val >> 1) & 0x1);
+  return AT86RF215_OK;
 }
 
 /**
@@ -1288,38 +1385,41 @@ int at86rf215_get_pll_ls(struct at86rf215 *h, at86rf215_pll_ls_t *status, at86rf
  * @param bw the RX bandwidth setting
  * @return 0 on success or negative error code
  */
-int at86rf215_set_bw(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t if_inv, uint8_t if_shift, at86rf215_rx_bw_t bw) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_set_bw(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t if_inv,
+                 uint8_t if_shift, at86rf215_rx_bw_t bw)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
 
-    switch (bw) {
-        case AT86RF215_RF_BW160KHZ_IF250KHZ:
-        case AT86RF215_RF_BW200KHZ_IF250KHZ:
-        case AT86RF215_RF_BW250KHZ_IF250KHZ:
-        case AT86RF215_RF_BW320KHZ_IF500KHZ:
-        case AT86RF215_RF_BW400KHZ_IF500KHZ:
-        case AT86RF215_RF_BW500KHZ_IF500KHZ:
-        case AT86RF215_RF_BW630KHZ_IF1000KHZ:
-        case AT86RF215_RF_BW800KHZ_IF1000KHZ:
-        case AT86RF215_RF_BW1000KHZ_IF1000KHZ:
-        case AT86RF215_RF_BW1250KHZ_IF2000KHZ:
-        case AT86RF215_RF_BW1600KHZ_IF2000KHZ:
-        case AT86RF215_RF_BW2000KHZ_IF2000KHZ:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+  switch (bw) {
+  case AT86RF215_RF_BW160KHZ_IF250KHZ:
+  case AT86RF215_RF_BW200KHZ_IF250KHZ:
+  case AT86RF215_RF_BW250KHZ_IF250KHZ:
+  case AT86RF215_RF_BW320KHZ_IF500KHZ:
+  case AT86RF215_RF_BW400KHZ_IF500KHZ:
+  case AT86RF215_RF_BW500KHZ_IF500KHZ:
+  case AT86RF215_RF_BW630KHZ_IF1000KHZ:
+  case AT86RF215_RF_BW800KHZ_IF1000KHZ:
+  case AT86RF215_RF_BW1000KHZ_IF1000KHZ:
+  case AT86RF215_RF_BW1250KHZ_IF2000KHZ:
+  case AT86RF215_RF_BW1600KHZ_IF2000KHZ:
+  case AT86RF215_RF_BW2000KHZ_IF2000KHZ:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_RXBWC;
-    } else {
-        reg = REG_RF24_RXBWC;
-    }
-    uint8_t val = ((if_inv & 0x1) << 5) | ((if_shift & 0x1) << 4) | bw;
-    return at86rf215_reg_write_8(h, val, reg);
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_RXBWC;
+  } else {
+    reg = REG_RF24_RXBWC;
+  }
+  uint8_t val = ((if_inv & 0x1) << 5) | ((if_shift & 0x1) << 4) | bw;
+  return at86rf215_reg_write_8(h, val, reg);
 }
 
 /**
@@ -1331,99 +1431,107 @@ int at86rf215_set_bw(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t if_in
  * @return 0 on success, -AT86RF215_INVAL_VAL in case of invalid RSSI
  * or other appropriate negative error code
  */
-int at86rf215_get_rssi(struct at86rf215 *h, at86rf215_radio_t radio, float *rssi) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_get_rssi(struct at86rf215 *h, at86rf215_radio_t radio, float *rssi)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
 
-    if (!rssi) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_RSSI;
-    } else {
-        reg = REG_RF24_RSSI;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    if ((int8_t)val == 127) {
-        return -AT86RF215_INVAL_VAL;
-    }
-    *rssi = (int8_t)val;
-    return AT86RF215_OK;
+  if (!rssi) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_RSSI;
+  } else {
+    reg = REG_RF24_RSSI;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  if ((int8_t)val == 127) {
+    return -AT86RF215_INVAL_VAL;
+  }
+  *rssi = (int8_t)val;
+  return AT86RF215_OK;
 }
 
-int at86rf215_get_edv(struct at86rf215 *h, at86rf215_radio_t radio, float *edv) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_get_edv(struct at86rf215 *h, at86rf215_radio_t radio, float *edv)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
 
-    if (!edv) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_EDV;
-    } else {
-        reg = REG_RF24_EDV;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    if ((int8_t)val == 127) {
-        return -AT86RF215_INVAL_VAL;
-    }
-    *edv = (int8_t)val;
-    return AT86RF215_OK;
+  if (!edv) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_EDV;
+  } else {
+    reg = REG_RF24_EDV;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  if ((int8_t)val == 127) {
+    return -AT86RF215_INVAL_VAL;
+  }
+  *edv = (int8_t)val;
+  return AT86RF215_OK;
 }
 
-int at86rf215_set_agc(struct at86rf215 *h, at86rf215_radio_t radio, const struct at86rf215_agc_conf *cnf) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!cnf) {
-        return -AT86RF215_INVAL_PARAM;
-    }
+int
+at86rf215_set_agc(struct at86rf215 *h, at86rf215_radio_t radio,
+                  const struct at86rf215_agc_conf *cnf)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!cnf) {
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    /* If AGC is enabled, user may pass an invalid value */
-    uint8_t gcw = cnf->gcw;
-    if (cnf->gcw > 23) {
-        gcw = 23;
-    }
+  /* If AGC is enabled, user may pass an invalid value */
+  uint8_t gcw = cnf->gcw;
+  if (cnf->gcw > 23) {
+    gcw = 23;
+  }
 
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AGCC;
-    } else {
-        reg = REG_RF24_AGCC;
-    }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AGCC;
+  } else {
+    reg = REG_RF24_AGCC;
+  }
 
-    uint8_t val = (cnf->input << 6) | (cnf->avgs << 4) | (cnf->reset << 3) | (cnf->freeze << 1) | cnf->enable;
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
+  uint8_t val = (cnf->input << 6) | (cnf->avgs << 4) | (cnf->reset << 3) |
+                (cnf->freeze << 1) | cnf->enable;
+  ret         = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
 
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AGCS;
-    } else {
-        reg = REG_RF24_AGCS;
-    }
-    val = (cnf->tgt << 5) | gcw;
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AGCS;
+  } else {
+    reg = REG_RF24_AGCS;
+  }
+  val = (cnf->tgt << 5) | gcw;
+  ret = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -1434,101 +1542,110 @@ int at86rf215_set_agc(struct at86rf215 *h, at86rf215_radio_t radio, const struct
  * @param tgt the AGC target
  * @return 0 on success or an appropriate negative error code
  */
-int at86rf215_set_agc_target(struct at86rf215 *h, at86rf215_radio_t radio, at86rf215_agc_tgt_t tgt) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
-    switch (tgt) {
-        case AT86RF215_TGT_M21:
-        case AT86RF215_TGT_M24:
-        case AT86RF215_TGT_M27:
-        case AT86RF215_TGT_M30:
-        case AT86RF215_TGT_M33:
-        case AT86RF215_TGT_M36:
-        case AT86RF215_TGT_M39:
-        case AT86RF215_TGT_M42:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+int
+at86rf215_set_agc_target(struct at86rf215 *h, at86rf215_radio_t radio,
+                         at86rf215_agc_tgt_t tgt)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  switch (tgt) {
+  case AT86RF215_TGT_M21:
+  case AT86RF215_TGT_M24:
+  case AT86RF215_TGT_M27:
+  case AT86RF215_TGT_M30:
+  case AT86RF215_TGT_M33:
+  case AT86RF215_TGT_M36:
+  case AT86RF215_TGT_M39:
+  case AT86RF215_TGT_M42:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AGCS;
-    } else {
-        reg = REG_RF24_AGCS;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AGCS;
+  } else {
+    reg = REG_RF24_AGCS;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
 
-    val &= 0x1F;
-    val |= (tgt << 5);
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+  val &= 0x1F;
+  val |= (tgt << 5);
+  ret = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
-int at86rf215_set_agc_control(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t freeze, uint8_t en) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AGCC;
-    } else {
-        reg = REG_RF24_AGCC;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    val &= 0xFC;
+int
+at86rf215_set_agc_control(struct at86rf215 *h, at86rf215_radio_t radio,
+                          uint8_t freeze, uint8_t en)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AGCC;
+  } else {
+    reg = REG_RF24_AGCC;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  val &= 0xFC;
 
-    val |= ((freeze & 0x1) << 1) | (en & 0x1);
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+  val |= ((freeze & 0x1) << 1) | (en & 0x1);
+  ret = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
-int at86rf215_set_agc_gain(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t gain) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_set_agc_gain(struct at86rf215 *h, at86rf215_radio_t radio,
+                       uint8_t gain)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
 
-    if (!gain) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AGCS;
-    } else {
-        reg = REG_RF24_AGCS;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    val &= 0xE0;
-    val |= (gain & 0x1F);
-    // FIXME
-    val |= 0x3 << 4;
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+  if (!gain) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AGCS;
+  } else {
+    reg = REG_RF24_AGCS;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  val &= 0xE0;
+  val |= (gain & 0x1F);
+  // FIXME
+  val |= 0x3 << 4;
+  ret = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -1539,85 +1656,96 @@ int at86rf215_set_agc_gain(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t
  * @param gain pointer to store the result
  * @return 0 on success or an appropriate negative error code
  */
-int at86rf215_get_agc_gain(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t *gain) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_get_agc_gain(struct at86rf215 *h, at86rf215_radio_t radio,
+                       uint8_t *gain)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
 
-    if (!gain) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AGCS;
-    } else {
-        reg = REG_RF24_AGCS;
-    }
-    uint8_t val = 0;
-    ret = at86rf215_reg_read_8(h, &val, reg);
-    if (ret) {
-        return ret;
-    }
-    *gain = val & 0x1F;
-    return AT86RF215_OK;
+  if (!gain) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AGCS;
+  } else {
+    reg = REG_RF24_AGCS;
+  }
+  uint8_t val = 0;
+  ret         = at86rf215_reg_read_8(h, &val, reg);
+  if (ret) {
+    return ret;
+  }
+  *gain = val & 0x1F;
+  return AT86RF215_OK;
 }
 
-int at86rf215_set_aux_settings(struct at86rf215 *h, at86rf215_radio_t radio, const struct at86rf215_aux_conf *cnf) {
-    int ret = radio_ready(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!cnf) {
-        return -AT86RF215_INVAL_PARAM;
-    }
+int
+at86rf215_set_aux_settings(struct at86rf215 *h, at86rf215_radio_t radio,
+                           const struct at86rf215_aux_conf *cnf)
+{
+  int ret = radio_ready(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!cnf) {
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    switch (cnf->agcmap) {
-        case AT86RF215_AGC_MAP_INTERNAL:
-        case AT86RF215_AGC_MAP_9DB:
-        case AT86RF215_AGC_MAP_12DB:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+  switch (cnf->agcmap) {
+  case AT86RF215_AGC_MAP_INTERNAL:
+  case AT86RF215_AGC_MAP_9DB:
+  case AT86RF215_AGC_MAP_12DB:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    switch (cnf->pavc) {
-        case AT86RF215_PAVC_2_0V:
-        case AT86RF215_PAVC_2_2V:
-        case AT86RF215_PAVC_2_4V:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-            ;
-    }
+  switch (cnf->pavc) {
+  case AT86RF215_PAVC_2_0V:
+  case AT86RF215_PAVC_2_2V:
+  case AT86RF215_PAVC_2_4V:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+    ;
+  }
 
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_RF09_AUXS;
-    } else {
-        reg = REG_RF24_AUXS;
-    }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_RF09_AUXS;
+  } else {
+    reg = REG_RF24_AUXS;
+  }
 
-    uint8_t val = (cnf->extlnabyp << 7) | (cnf->agcmap << 5) | (cnf->avext << 4) | (cnf->aven << 3) | cnf->pavc;
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+  uint8_t val = (cnf->extlnabyp << 7) | (cnf->agcmap << 5) | (cnf->avext << 4) |
+                (cnf->aven << 3) | cnf->pavc;
+  ret         = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
-static void handle_bb_irq(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t bbcn_irqs) {
-    struct at86rf215_radio *r = &h->priv.radios[radio];
-    if (bbcn_irqs & BIT(4)) {
-        r->tx_complete = 1;
-    }
+static void
+handle_bb_irq(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t bbcn_irqs)
+{
+  struct at86rf215_radio *r = &h->priv.radios[radio];
+  if (bbcn_irqs & BIT(4)) {
+    r->tx_complete = 1;
+  }
 }
 
-static void handle_rf_irq(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t rfn_irqs) {
-    struct at86rf215_radio *r = &h->priv.radios[radio];
-    if (rfn_irqs & BIT(1)) {
-        r->trxready = 1;
-    }
+static void
+handle_rf_irq(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t rfn_irqs)
+{
+  struct at86rf215_radio *r = &h->priv.radios[radio];
+  if (rfn_irqs & BIT(1)) {
+    r->trxready = 1;
+  }
 }
 
 /**
@@ -1628,29 +1756,31 @@ static void handle_rf_irq(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t 
  * @param h the device handle
  * @return 0 on success or negative error code
  */
-int at86rf215_irq_callback(struct at86rf215 *h) {
-    int ret = ready(h);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_irq_callback(struct at86rf215 *h)
+{
+  int ret = ready(h);
+  if (ret) {
+    return ret;
+  }
 
-    /*
-     * Read and acknowledge all IRQ sources
-     * NOTE: Block mode did not acknowledged the triggered IRQs, even if
-     * the manual says that it should
-     */
-    uint8_t irqs[4] = {0x0, 0x0, 0x0, 0x0};
-    at86rf215_reg_read_8(h, &irqs[0], REG_RF09_IRQS);
-    at86rf215_reg_read_8(h, &irqs[1], REG_RF24_IRQS);
-    at86rf215_reg_read_8(h, &irqs[2], REG_BBC0_IRQS);
-    at86rf215_reg_read_8(h, &irqs[3], REG_BBC1_IRQS);
+  /*
+   * Read and acknowledge all IRQ sources
+   * NOTE: Block mode did not acknowledged the triggered IRQs, even if
+   * the manual says that it should
+   */
+  uint8_t irqs[4] = {0x0, 0x0, 0x0, 0x0};
+  at86rf215_reg_read_8(h, &irqs[0], REG_RF09_IRQS);
+  at86rf215_reg_read_8(h, &irqs[1], REG_RF24_IRQS);
+  at86rf215_reg_read_8(h, &irqs[2], REG_BBC0_IRQS);
+  at86rf215_reg_read_8(h, &irqs[3], REG_BBC1_IRQS);
 
-    handle_rf_irq(h, AT86RF215_RF09, irqs[0]);
-    handle_rf_irq(h, AT86RF215_RF24, irqs[1]);
-    handle_bb_irq(h, AT86RF215_RF09, irqs[2]);
-    handle_bb_irq(h, AT86RF215_RF24, irqs[3]);
+  handle_rf_irq(h, AT86RF215_RF09, irqs[0]);
+  handle_rf_irq(h, AT86RF215_RF24, irqs[1]);
+  handle_bb_irq(h, AT86RF215_RF09, irqs[2]);
+  handle_bb_irq(h, AT86RF215_RF24, irqs[3]);
 
-    return at86rf215_irq_user_callback(h, irqs[0], irqs[1], irqs[2], irqs[3]);
+  return at86rf215_irq_user_callback(h, irqs[0], irqs[1], irqs[2], irqs[3]);
 }
 
 /**
@@ -1659,23 +1789,25 @@ int at86rf215_irq_callback(struct at86rf215 *h) {
  * @param h the device handle
  * @return 0 on success or negative error code
  */
-int at86rf215_irq_clear(struct at86rf215 *h) {
-    int ret = ready(h);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_irq_clear(struct at86rf215 *h)
+{
+  int ret = ready(h);
+  if (ret) {
+    return ret;
+  }
 
-    /*
-     * Read and acknowledge all IRQ sources
-     * NOTE: Block mode did not acknowledged the triggered IRQs, even if
-     * the manual says that it should
-     */
-    uint8_t irqs;
-    at86rf215_reg_read_8(h, &irqs, REG_RF09_IRQS);
-    at86rf215_reg_read_8(h, &irqs, REG_RF24_IRQS);
-    at86rf215_reg_read_8(h, &irqs, REG_BBC0_IRQS);
-    at86rf215_reg_read_8(h, &irqs, REG_BBC1_IRQS);
-    return AT86RF215_OK;
+  /*
+   * Read and acknowledge all IRQ sources
+   * NOTE: Block mode did not acknowledged the triggered IRQs, even if
+   * the manual says that it should
+   */
+  uint8_t irqs;
+  at86rf215_reg_read_8(h, &irqs, REG_RF09_IRQS);
+  at86rf215_reg_read_8(h, &irqs, REG_RF24_IRQS);
+  at86rf215_reg_read_8(h, &irqs, REG_BBC0_IRQS);
+  at86rf215_reg_read_8(h, &irqs, REG_BBC1_IRQS);
+  return AT86RF215_OK;
 }
 
 /**
@@ -1685,31 +1817,33 @@ int at86rf215_irq_clear(struct at86rf215 *h) {
  * @param radio the RF frontend
  * @return 0 on success or negative error code
  */
-int at86rf215_radio_irq_clear(struct at86rf215 *h, at86rf215_radio_t radio) {
-    int ret = ready(h);
-    if (ret) {
-        return ret;
-    }
+int
+at86rf215_radio_irq_clear(struct at86rf215 *h, at86rf215_radio_t radio)
+{
+  int ret = ready(h);
+  if (ret) {
+    return ret;
+  }
 
-    /*
-     * Read and acknowledge all IRQ sources
-     * NOTE: Block mode did not acknowledged the triggered IRQs, even if
-     * the manual says that it should
-     */
-    uint8_t irqs;
-    switch (radio) {
-        case AT86RF215_RF09:
-            at86rf215_reg_read_8(h, &irqs, REG_RF09_IRQS);
-            at86rf215_reg_read_8(h, &irqs, REG_BBC0_IRQS);
-            break;
-        case AT86RF215_RF24:
-            at86rf215_reg_read_8(h, &irqs, REG_RF24_IRQS);
-            at86rf215_reg_read_8(h, &irqs, REG_BBC1_IRQS);
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    return AT86RF215_OK;
+  /*
+   * Read and acknowledge all IRQ sources
+   * NOTE: Block mode did not acknowledged the triggered IRQs, even if
+   * the manual says that it should
+   */
+  uint8_t irqs;
+  switch (radio) {
+  case AT86RF215_RF09:
+    at86rf215_reg_read_8(h, &irqs, REG_RF09_IRQS);
+    at86rf215_reg_read_8(h, &irqs, REG_BBC0_IRQS);
+    break;
+  case AT86RF215_RF24:
+    at86rf215_reg_read_8(h, &irqs, REG_RF24_IRQS);
+    at86rf215_reg_read_8(h, &irqs, REG_BBC1_IRQS);
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -1721,314 +1855,594 @@ int at86rf215_radio_irq_clear(struct at86rf215 *h, at86rf215_radio_t radio) {
  * @param bbc1_irqs BBC1_IRQS register
  * @return 0 on success or negative error code
  */
-__attribute__((weak)) int at86rf215_irq_user_callback(struct at86rf215 *h, uint8_t rf09_irqs, uint8_t rf24_irqs, uint8_t bbc0_irqs,
-                                                      uint8_t bbc1_irqs) {
-    return AT86RF215_OK;
+__attribute__((weak)) int
+at86rf215_irq_user_callback(struct at86rf215 *h, uint8_t rf09_irqs,
+                            uint8_t rf24_irqs, uint8_t bbc0_irqs,
+                            uint8_t bbc1_irqs)
+{
+  return AT86RF215_OK;
 }
 
-static int bb_conf_mrfsk(struct at86rf215 *h, at86rf215_radio_t radio, const struct at86rf215_bb_conf *conf) {
-    /*
-     * In order to process efficiently the configuration registers for
-     * the two available baseband cores, we use the constant offset of the
-     * configuration address space of the two cores. For some RF related
-     * configuration registers (e.g. TXDFE, RXDFE) the offset between the
-     * two address spaces for the radio configuration is exactly the same.
-     */
-    uint16_t offset;
-    switch (radio) {
-        case AT86RF215_RF09:
-            offset = 0;
-            break;
-        case AT86RF215_RF24:
-            offset = 256;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+static int
+bb_conf_mrfsk(struct at86rf215 *h, at86rf215_radio_t radio,
+              const struct at86rf215_bb_conf *conf)
+{
+  /*
+   * In order to process efficiently the configuration registers for
+   * the two available baseband cores, we use the constant offset of the
+   * configuration address space of the two cores. For some RF related
+   * configuration registers (e.g. TXDFE, RXDFE) the offset between the
+   * two address spaces for the radio configuration is exactly the same.
+   */
+  uint16_t offset;
+  switch (radio) {
+  case AT86RF215_RF09:
+    offset = 0;
+    break;
+  case AT86RF215_RF24:
+    offset = 256;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    at86rf215_sr_t tx_sr = AT86RF215_SR_4000KHZ;
-    at86rf215_sr_t rx_sr = AT86RF215_SR_4000KHZ;
-    switch (conf->fsk.srate) {
-        case AT86RF215_FSK_SRATE_50:
-            if (h->priv.version == 1) {
-                tx_sr = AT86RF215_SR_400KHZ;
-            } else {
-                tx_sr = AT86RF215_SR_500KHZ;
-            }
-            rx_sr = AT86RF215_SR_400KHZ;
-            break;
-        case AT86RF215_FSK_SRATE_100:
-            if (h->priv.version == 1) {
-                tx_sr = AT86RF215_SR_800KHZ;
-            } else {
-                tx_sr = AT86RF215_SR_1000KHZ;
-            }
-            rx_sr = AT86RF215_SR_800KHZ;
-            break;
-        case AT86RF215_FSK_SRATE_150:
-            tx_sr = AT86RF215_SR_2000KHZ;
-            rx_sr = AT86RF215_SR_1000KHZ;
-            break;
-        case AT86RF215_FSK_SRATE_200:
-            tx_sr = AT86RF215_SR_2000KHZ;
-            rx_sr = AT86RF215_SR_1000KHZ;
-            break;
-        case AT86RF215_FSK_SRATE_300:
-            tx_sr = AT86RF215_SR_4000KHZ;
-            rx_sr = AT86RF215_SR_2000KHZ;
-            break;
-        case AT86RF215_FSK_SRATE_400:
-            tx_sr = AT86RF215_SR_4000KHZ;
-            rx_sr = AT86RF215_SR_2000KHZ;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-
-    at86rf215_rcut_t rx_rcut = AT86RF215_RCUT_25FS2;
-    uint8_t ifs = 0;
-    at86rf215_rx_bw_t rbw = AT86RF215_RF_BW160KHZ_IF250KHZ;
-    if (conf->fsk.midx >= AT86RF215_MIDX_3) {
-        if (radio == AT86RF215_RF09) {
-            rx_rcut = fsk_rx_conf_rcut_midx3_09[conf->fsk.srate];
-            rbw = fsk_rx_conf_rbw_midx3_09[conf->fsk.srate];
-            ifs = fsk_rx_conf_ifs_midx3_09[conf->fsk.srate];
-        } else {
-            rx_rcut = fsk_rx_conf_rcut_midx3_24[conf->fsk.srate];
-            rbw = fsk_rx_conf_rbw_midx3_24[conf->fsk.srate];
-            ifs = fsk_rx_conf_ifs_midx3_24[conf->fsk.srate];
-        }
+  at86rf215_sr_t tx_sr = AT86RF215_SR_4000KHZ;
+  at86rf215_sr_t rx_sr = AT86RF215_SR_4000KHZ;
+  switch (conf->fsk.srate) {
+  case AT86RF215_FSK_SRATE_50:
+    if (h->priv.version == 1) {
+      tx_sr = AT86RF215_SR_400KHZ;
     } else {
-        if (radio == AT86RF215_RF09) {
-            rx_rcut = fsk_rx_conf_rcut_midx1_09[conf->fsk.srate];
-            rbw = fsk_rx_conf_rbw_midx1_09[conf->fsk.srate];
-            ifs = fsk_rx_conf_ifs_midx1_09[conf->fsk.srate];
-        } else {
-            rx_rcut = fsk_rx_conf_rcut_midx1_24[conf->fsk.srate];
-            rbw = fsk_rx_conf_rbw_midx1_24[conf->fsk.srate];
-            ifs = fsk_rx_conf_ifs_midx1_24[conf->fsk.srate];
-        }
+      tx_sr = AT86RF215_SR_500KHZ;
     }
-
-    at86rf215_rcut_t tx_rcut = AT86RF215_RCUT_25FS2;
-    if (conf->fsk.midx >= AT86RF215_MIDX_3) {
-        tx_rcut = fsk_tx_conf_rcut_midx3[conf->fsk.srate];
+    rx_sr = AT86RF215_SR_400KHZ;
+    break;
+  case AT86RF215_FSK_SRATE_100:
+    if (h->priv.version == 1) {
+      tx_sr = AT86RF215_SR_800KHZ;
     } else {
-        tx_rcut = fsk_tx_conf_rcut_midx1[conf->fsk.srate];
+      tx_sr = AT86RF215_SR_1000KHZ;
     }
+    rx_sr = AT86RF215_SR_800KHZ;
+    break;
+  case AT86RF215_FSK_SRATE_150:
+    tx_sr = AT86RF215_SR_2000KHZ;
+    rx_sr = AT86RF215_SR_1000KHZ;
+    break;
+  case AT86RF215_FSK_SRATE_200:
+    tx_sr = AT86RF215_SR_2000KHZ;
+    rx_sr = AT86RF215_SR_1000KHZ;
+    break;
+  case AT86RF215_FSK_SRATE_300:
+    tx_sr = AT86RF215_SR_4000KHZ;
+    rx_sr = AT86RF215_SR_2000KHZ;
+    break;
+  case AT86RF215_FSK_SRATE_400:
+    tx_sr = AT86RF215_SR_4000KHZ;
+    rx_sr = AT86RF215_SR_2000KHZ;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    uint8_t val;
-    /* FSKC0 */
-    switch (conf->fsk.mord) {
-        case AT86RF215_2FSK:
-            break;
-        case AT86RF215_4FSK:
-            /* Check for 4FSK restrictions (h >= 1, BT = 2) */
-            if (conf->fsk.bt != 2 || conf->fsk.midx < AT86RF215_MIDX_3) {
-                return -AT86RF215_INVAL_CONF;
-            }
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
+  at86rf215_rcut_t  rx_rcut = AT86RF215_RCUT_25FS2;
+  uint8_t           ifs     = 0;
+  at86rf215_rx_bw_t rbw     = AT86RF215_RF_BW160KHZ_IF250KHZ;
+  if (conf->fsk.midx >= AT86RF215_MIDX_3) {
+    if (radio == AT86RF215_RF09) {
+      rx_rcut = fsk_rx_conf_rcut_midx3_09[conf->fsk.srate];
+      rbw     = fsk_rx_conf_rbw_midx3_09[conf->fsk.srate];
+      ifs     = fsk_rx_conf_ifs_midx3_09[conf->fsk.srate];
+    } else {
+      rx_rcut = fsk_rx_conf_rcut_midx3_24[conf->fsk.srate];
+      rbw     = fsk_rx_conf_rbw_midx3_24[conf->fsk.srate];
+      ifs     = fsk_rx_conf_ifs_midx3_24[conf->fsk.srate];
     }
-    val = conf->fsk.mord;
-    switch (conf->fsk.midx) {
-        case AT86RF215_MIDX_0:
-        case AT86RF215_MIDX_1:
-        case AT86RF215_MIDX_2:
-        case AT86RF215_MIDX_3:
-        case AT86RF215_MIDX_4:
-        case AT86RF215_MIDX_5:
-        case AT86RF215_MIDX_6:
-        case AT86RF215_MIDX_7:
-            val |= conf->fsk.midx << 1;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
+  } else {
+    if (radio == AT86RF215_RF09) {
+      rx_rcut = fsk_rx_conf_rcut_midx1_09[conf->fsk.srate];
+      rbw     = fsk_rx_conf_rbw_midx1_09[conf->fsk.srate];
+      ifs     = fsk_rx_conf_ifs_midx1_09[conf->fsk.srate];
+    } else {
+      rx_rcut = fsk_rx_conf_rcut_midx1_24[conf->fsk.srate];
+      rbw     = fsk_rx_conf_rbw_midx1_24[conf->fsk.srate];
+      ifs     = fsk_rx_conf_ifs_midx1_24[conf->fsk.srate];
     }
+  }
 
-    switch (conf->fsk.midxs) {
-        case AT86RF215_MIDXS_78:
-        case AT86RF215_MIDXS_88:
-        case AT86RF215_MIDXS_98:
-        case AT86RF215_MIDXS_108:
-            val |= conf->fsk.midxs << 4;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    switch (conf->fsk.bt) {
-        case AT86RF215_FSK_BT_05:
-        case AT86RF215_FSK_BT_10:
-        case AT86RF215_FSK_BT_15:
-        case AT86RF215_FSK_BT_20:
-            val |= conf->fsk.bt << 6;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    int ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC0 + offset);
-    if (ret) {
-        return ret;
-    }
+  at86rf215_rcut_t tx_rcut = AT86RF215_RCUT_25FS2;
+  if (conf->fsk.midx >= AT86RF215_MIDX_3) {
+    tx_rcut = fsk_tx_conf_rcut_midx3[conf->fsk.srate];
+  } else {
+    tx_rcut = fsk_tx_conf_rcut_midx1[conf->fsk.srate];
+  }
 
-    /* FSKC1 */
-    val = conf->fsk.srate | (conf->fsk.fi << 5) | ((conf->fsk.preamble_length >> 2) & 0xC0);
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC1 + offset);
-    if (ret) {
-        return ret;
+  uint8_t val;
+  /* FSKC0 */
+  switch (conf->fsk.mord) {
+  case AT86RF215_2FSK:
+    break;
+  case AT86RF215_4FSK:
+    /* Check for 4FSK restrictions (h >= 1, BT = 2) */
+    if (conf->fsk.bt != 2 || conf->fsk.midx < AT86RF215_MIDX_3) {
+      return -AT86RF215_INVAL_CONF;
     }
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  val = conf->fsk.mord;
+  switch (conf->fsk.midx) {
+  case AT86RF215_MIDX_0:
+  case AT86RF215_MIDX_1:
+  case AT86RF215_MIDX_2:
+  case AT86RF215_MIDX_3:
+  case AT86RF215_MIDX_4:
+  case AT86RF215_MIDX_5:
+  case AT86RF215_MIDX_6:
+  case AT86RF215_MIDX_7:
+    val |= conf->fsk.midx << 1;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    /* FSKC2 */
-    val = conf->fsk.fecie;
-    switch (conf->fsk.fecs) {
-        case AT86RF215_FSK_FEC_NRNSC:
-        case AT86RF215_FSK_FEC_RSC:
-            val |= conf->fsk.fecs << 1;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    val |= (conf->fsk.pri << 2) | (conf->fsk.mse << 3) | (conf->fsk.rxpto << 4);
-    switch (conf->fsk.rxo) {
-        case AT86RF215_FSK_RXO_6DB:
-        case AT86RF215_FSK_RXO_12DB:
-        case AT86RF215_FSK_RXO_18DB:
-        case AT86RF215_FSK_RXO_DISABLED:
-            val |= conf->fsk.rxo << 5;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    val |= conf->fsk.pdtm << 7;
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC2 + offset);
-    if (ret) {
-        return ret;
-    }
+  switch (conf->fsk.midxs) {
+  case AT86RF215_MIDXS_78:
+  case AT86RF215_MIDXS_88:
+  case AT86RF215_MIDXS_98:
+  case AT86RF215_MIDXS_108:
+    val |= conf->fsk.midxs << 4;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  switch (conf->fsk.bt) {
+  case AT86RF215_FSK_BT_05:
+  case AT86RF215_FSK_BT_10:
+  case AT86RF215_FSK_BT_15:
+  case AT86RF215_FSK_BT_20:
+    val |= conf->fsk.bt << 6;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  int ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC0 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* FSKC3 */
-    val = (conf->fsk.sfd_threshold << 4) | conf->fsk.preamble_threshold;
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC3 + offset);
-    if (ret) {
-        return ret;
-    }
+  /* FSKC1 */
+  val = conf->fsk.srate | (conf->fsk.fi << 5) |
+        ((conf->fsk.preamble_length >> 2) & 0xC0);
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC1 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* FSKC4 */
-    switch (conf->fsk.csfd0) {
-        case AT86RF215_SFD_UNCODED_IEEE:
-        case AT86RF215_SFD_UNCODED_RAW:
-        case AT86RF215_SFD_CODED_IEEE:
-        case AT86RF215_SFD_CODED_RAW:
-            val = conf->fsk.csfd0;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    switch (conf->fsk.csfd1) {
-        case AT86RF215_SFD_UNCODED_IEEE:
-        case AT86RF215_SFD_UNCODED_RAW:
-        case AT86RF215_SFD_CODED_IEEE:
-        case AT86RF215_SFD_CODED_RAW:
-            val |= conf->fsk.csfd1 << 2;
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    val |= (conf->fsk.rawrbit << 4) | (conf->fsk.sfd32 << 5) | (conf->fsk.sfdq << 6);
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC4 + offset);
-    if (ret) {
-        return ret;
-    }
+  /* FSKC2 */
+  val = conf->fsk.fecie;
+  switch (conf->fsk.fecs) {
+  case AT86RF215_FSK_FEC_NRNSC:
+  case AT86RF215_FSK_FEC_RSC:
+    val |= conf->fsk.fecs << 1;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  val |= (conf->fsk.pri << 2) | (conf->fsk.mse << 3) | (conf->fsk.rxpto << 4);
+  switch (conf->fsk.rxo) {
+  case AT86RF215_FSK_RXO_6DB:
+  case AT86RF215_FSK_RXO_12DB:
+  case AT86RF215_FSK_RXO_18DB:
+  case AT86RF215_FSK_RXO_DISABLED:
+    val |= conf->fsk.rxo << 5;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  val |= conf->fsk.pdtm << 7;
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC2 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* FSKPLL */
-    val = conf->fsk.preamble_length;
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKPLL + offset);
-    if (ret) {
-        return ret;
-    }
+  /* FSKC3 */
+  val = (conf->fsk.sfd_threshold << 4) | conf->fsk.preamble_threshold;
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC3 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* SFD configuration */
-    ret = at86rf215_reg_write_8(h, conf->fsk.sfd0, REG_BBC0_FSKSFD0L + offset);
-    if (ret) {
-        return ret;
-    }
-    ret = at86rf215_reg_write_8(h, conf->fsk.sfd0 >> 8, REG_BBC0_FSKSFD0H + offset);
-    if (ret) {
-        return ret;
-    }
-    ret = at86rf215_reg_write_8(h, conf->fsk.sfd1, REG_BBC0_FSKSFD1L + offset);
-    if (ret) {
-        return ret;
-    }
-    ret = at86rf215_reg_write_8(h, conf->fsk.sfd1 >> 8, REG_BBC0_FSKSFD1H + offset);
-    if (ret) {
-        return ret;
-    }
+  /* FSKC4 */
+  switch (conf->fsk.csfd0) {
+  case AT86RF215_SFD_UNCODED_IEEE:
+  case AT86RF215_SFD_UNCODED_RAW:
+  case AT86RF215_SFD_CODED_IEEE:
+  case AT86RF215_SFD_CODED_RAW:
+    val = conf->fsk.csfd0;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  switch (conf->fsk.csfd1) {
+  case AT86RF215_SFD_UNCODED_IEEE:
+  case AT86RF215_SFD_UNCODED_RAW:
+  case AT86RF215_SFD_CODED_IEEE:
+  case AT86RF215_SFD_CODED_RAW:
+    val |= conf->fsk.csfd1 << 2;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  val |=
+      (conf->fsk.rawrbit << 4) | (conf->fsk.sfd32 << 5) | (conf->fsk.sfdq << 6);
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKC4 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* FSKPHRTX */
-    val = conf->fsk.rb1 | (conf->fsk.rb2 << 1) | (conf->fsk.dw << 2) | (conf->fsk.sfd << 3);
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKPHRTX + offset);
-    if (ret) {
-        return ret;
-    }
+  /* FSKPLL */
+  val = conf->fsk.preamble_length;
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKPLL + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /*
-     * FSKDM
-     * NOTE: Both TXDFE and FSK DM should have the direct modulation option
-     * enabled
-     */
-    ret = at86rf215_reg_write_8(h, conf->fsk.dm | (conf->fsk.preemphasis << 1), REG_BBC0_FSKDM + offset);
-    if (ret) {
-        return ret;
-    }
+  /* SFD configuration */
+  ret = at86rf215_reg_write_8(h, conf->fsk.sfd0, REG_BBC0_FSKSFD0L + offset);
+  if (ret) {
+    return ret;
+  }
+  ret =
+      at86rf215_reg_write_8(h, conf->fsk.sfd0 >> 8, REG_BBC0_FSKSFD0H + offset);
+  if (ret) {
+    return ret;
+  }
+  ret = at86rf215_reg_write_8(h, conf->fsk.sfd1, REG_BBC0_FSKSFD1L + offset);
+  if (ret) {
+    return ret;
+  }
+  ret =
+      at86rf215_reg_write_8(h, conf->fsk.sfd1 >> 8, REG_BBC0_FSKSFD1H + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* PRemphasis filter setup */
-    ret = at86rf215_reg_write_8(h, conf->fsk.preemphasis_taps, REG_BBC0_FSKPE0 + offset);
-    if (ret) {
-        return ret;
-    }
+  /* FSKPHRTX */
+  val = conf->fsk.rb1 | (conf->fsk.rb2 << 1) | (conf->fsk.dw << 2) |
+        (conf->fsk.sfd << 3);
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKPHRTX + offset);
+  if (ret) {
+    return ret;
+  }
 
-    ret = at86rf215_reg_write_8(h, conf->fsk.preemphasis_taps >> 8, REG_BBC0_FSKPE1 + offset);
-    if (ret) {
-        return ret;
-    }
+  /*
+   * FSKDM
+   * NOTE: Both TXDFE and FSK DM should have the direct modulation option
+   * enabled
+   */
+  ret = at86rf215_reg_write_8(h, conf->fsk.dm | (conf->fsk.preemphasis << 1),
+                              REG_BBC0_FSKDM + offset);
+  if (ret) {
+    return ret;
+  }
 
-    ret = at86rf215_reg_write_8(h, conf->fsk.preemphasis_taps >> 16, REG_BBC0_FSKPE2 + offset);
-    if (ret) {
-        return ret;
-    }
+  /* PRemphasis filter setup */
+  ret = at86rf215_reg_write_8(h, conf->fsk.preemphasis_taps,
+                              REG_BBC0_FSKPE0 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply TX sampling rate and cutoff frequency */
-    ret = set_txdfe(h, radio, tx_rcut, conf->fsk.dm, tx_sr);
-    if (ret) {
-        return ret;
-    }
+  ret = at86rf215_reg_write_8(h, conf->fsk.preemphasis_taps >> 8,
+                              REG_BBC0_FSKPE1 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply RX sampling rate and cutoff frequency */
-    ret = set_rxdfe(h, radio, rx_rcut, rx_sr);
-    if (ret) {
-        return ret;
-    }
+  ret = at86rf215_reg_write_8(h, conf->fsk.preemphasis_taps >> 16,
+                              REG_BBC0_FSKPE2 + offset);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply RX filtering */
-    ret = at86rf215_set_bw(h, radio, 0, ifs, rbw);
-    if (ret) {
-        return ret;
-    }
+  /* Apply TX sampling rate and cutoff frequency */
+  ret = set_txdfe(h, radio, tx_rcut, conf->fsk.dm, tx_sr);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply FSK frame length for RAW mode */
-    val = conf->fsk.fskrrxf >> 8;
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKRRXFLH + offset);
-    if (ret) {
-        return ret;
-    }
-    val = conf->fsk.fskrrxf;
-    ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKRRXFLL + offset);
-    if (ret) {
-        return ret;
-    }
+  /* Apply RX sampling rate and cutoff frequency */
+  ret = set_rxdfe(h, radio, rx_rcut, rx_sr);
+  if (ret) {
+    return ret;
+  }
 
-    return AT86RF215_OK;
+  /* Apply RX filtering */
+  ret = at86rf215_set_bw(h, radio, 0, ifs, rbw);
+  if (ret) {
+    return ret;
+  }
+
+  /* Apply FSK frame length for RAW mode */
+  val = conf->fsk.fskrrxf >> 8;
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKRRXFLH + offset);
+  if (ret) {
+    return ret;
+  }
+  val = conf->fsk.fskrrxf;
+  ret = at86rf215_reg_write_8(h, val, REG_BBC0_FSKRRXFLL + offset);
+  if (ret) {
+    return ret;
+  }
+
+  return AT86RF215_OK;
+}
+
+static int
+bb_conf_mroqpsk(struct at86rf215 *h, at86rf215_radio_t radio,
+                const struct at86rf215_bb_conf *conf)
+{
+  /*
+   * In order to process efficiently the configuration registers for
+   * the two available baseband cores, we use the constant offset of the
+   * configuration address space of the two cores. For some RF related
+   * configuration registers (e.g. TXDFE, RXDFE) the offset between the
+   * two address spaces for the radio configuration is exactly the same.
+   */
+
+  if (h == NULL || conf == NULL) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+
+  uint16_t offset = 0;
+  int      ret    = 0;
+  switch (radio) {
+  case AT86RF215_RF09:
+    offset = 0;
+    break;
+  case AT86RF215_RF24:
+    offset = 256;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  /* Tx frontend configuration (Table 6-103) */
+  uint8_t txcutc_paramp = 0, txcutc_lpfcut = 0, txdfe_sr = 0, txdfe_rcut = 0;
+  /* Rx filter frontend configuration (Table 6-105) */
+  uint8_t rxbwc_bw = 0, rxbwc_ifs = 0, rxdfe_sr = 0, rxdfe_rcut = 0,
+          edd_dtb = 0, edd_df = 0;
+  /* Rx AGC frontend configuration (Table 6-106) */
+  uint8_t agcc_agci = 0, agcc_avgs = 0, agcc_en = 0, agcs_tgt = 0;
+  switch (conf->qpsk.fchip) {
+  case AT86RF215_MROQPSK_FCHIP_100:
+    /* txf */
+    txcutc_paramp = 0x3;
+    txcutc_lpfcut = 0x7;
+    txdfe_sr      = 0xA;
+    txdfe_rcut    = 0x3;
+
+    /* rxf */
+    rxbwc_bw   = 0x0;
+    rxbwc_ifs  = 0x0;
+    rxdfe_sr   = 0xA;
+    rxdfe_rcut = 0x1;
+    edd_dtb    = 0x3;
+    edd_df     = 0xA;
+
+    /* rxagc */
+    agcc_agci = 0x0;
+    agcc_avgs = 0x2;
+    agcc_en   = 0x1;
+    agcs_tgt  = 0x3;
+    break;
+  case AT86RF215_MROQPSK_FCHIP_200:
+    /* txf */
+    txcutc_paramp = 0x2;
+    txcutc_lpfcut = 0x7;
+    txdfe_sr      = 0x5;
+    txdfe_rcut    = 0x3;
+
+    /* rxf */
+    rxbwc_bw   = 0x2;
+    rxbwc_ifs  = 0x0;
+    rxdfe_sr   = 0x5;
+    rxdfe_rcut = 0x1;
+    edd_dtb    = 0x3;
+    edd_df     = 0x5;
+
+    /* rxagc */
+    agcc_agci = 0x0;
+    agcc_avgs = 0x2;
+    agcc_en   = 0x1;
+    agcs_tgt  = 0x3;
+    break;
+  case AT86RF215_MROQPSK_FCHIP_1000:
+    /* txf */
+    txcutc_paramp = 0x0;
+    txcutc_lpfcut = 0xB;
+    txdfe_sr      = 0x1;
+    txdfe_rcut    = 0x3;
+
+    /* rxf */
+    rxbwc_bw   = 0x8;
+    rxbwc_ifs  = 0x0;
+    rxdfe_sr   = 0x1;
+    rxdfe_rcut = 0x0;
+    edd_dtb    = 0x3;
+    edd_df     = 0x4;
+
+    /* rxagc */
+    agcc_agci = 0x0;
+    agcc_avgs = 0x0;
+    agcc_en   = 0x1;
+    agcs_tgt  = 0x3;
+    break;
+  case AT86RF215_MROQPSK_FCHIP_2000:
+    /* txf */
+    txcutc_paramp = 0x0;
+    txcutc_lpfcut = 0xB;
+    txdfe_sr      = 0x1;
+    txdfe_rcut    = 0x4;
+
+    /* rxf */
+    rxbwc_bw   = 0xB;
+    rxbwc_ifs  = 0x0;
+    rxdfe_sr   = 0x1;
+    rxdfe_rcut = 0x2;
+    edd_dtb    = 0x3;
+    edd_df     = 0x4;
+
+    /* rxagc */
+    agcc_agci = 0x0;
+    agcc_avgs = 0x0;
+    agcc_en   = 0x1;
+    agcs_tgt  = 0x3;
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+
+  switch (conf->qpsk.fshape_mod) {
+  case AT86RF215_MROQPSK_BB_RC08:
+  case AT86RF215_MROQPSK_BB_RRC08:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  switch (conf->qpsk.rxm) {
+  case AT86RF215_MROQPSK_RXM_MROQPSK_ONLY:
+  case AT86RF215_MROQPSK_RXM_LEGACY_ONLY:
+  case AT86RF215_MROQPSK_RXM_BOTH:
+  case AT86RF215_MROQPSK_RXM_DISABLED:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  switch (conf->qpsk.nsfd) {
+  case AT86RF215_MROQPSK_NSFD_SFD1:
+  case AT86RF215_MROQPSK_NSFD_SFD1_SFD2:
+  case AT86RF215_MROQPSK_NSFD_SFD1_SFD3:
+  case AT86RF215_MROQPSK_NSFD_SFD1_SFD2_SFD3:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  switch (conf->qpsk.drate_mod) {
+  case AT86RF215_MROQPSK_DRATE_MOD_0:
+  case AT86RF215_MROQPSK_DRATE_MOD_1:
+  case AT86RF215_MROQPSK_DRATE_MOD_2:
+  case AT86RF215_MROQPSK_DRATE_MOD_3:
+  case AT86RF215_MROQPSK_DRATE_MOD_4:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+
+  /* DM only valid on 100k Chip/s or 200k Chip/s */
+  if (conf->qpsk.dm && conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_100 &&
+      conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_200) {
+    return -AT86RF215_INVAL_CONF;
+  }
+  /* DM requires AT86RF215 v.3 silicon (RF_VN = 0x03), (6.12.2.2) */
+  if (conf->qpsk.dm && h->priv.version < 3) {
+    return -AT86RF215_NOT_SUPPORTED;
+  }
+  /* RXM = BOTH only enabled on FCHIP >= 1000k Chip/s */
+  if (conf->qpsk.rxm == AT86RF215_MROQPSK_RXM_BOTH &&
+      conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_1000 &&
+      conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_2000) {
+    return -AT86RF215_INVAL_CONF;
+  }
+  /* Rate mode 4 only valid at 2000k chip/s */
+  if (conf->qpsk.drate_mod == AT86RF215_MROQPSK_DRATE_MOD_4 &&
+      conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_2000) {
+    return -AT86RF215_INVAL_CONF;
+  }
+
+  /* OQPSKC0 */
+  uint8_t reg_oqpskc0 = ((conf->qpsk.dm & 0x01) << 4) |
+                        ((conf->qpsk.fshape_mod & 0x01) << 3) |
+                        (conf->qpsk.fchip & 0x03);
+  ret = at86rf215_reg_write_8(h, reg_oqpskc0, REG_BBC0_OQPSKC0 + offset);
+  if (ret) {
+    return ret;
+  }
+  /* OQPSKC1 */
+  uint8_t reg_oqpskc1 =
+      ((conf->qpsk.rxo & 0x01) << 7) | ((conf->qpsk.rxoleg & 0x01) << 6) |
+      ((conf->qpsk.pdt1 & 0x07) << 3) | (conf->qpsk.pdt0 & 0x07);
+  ret = at86rf215_reg_write_8(h, reg_oqpskc1, REG_BBC0_OQPSKC1 + offset);
+  if (ret) {
+    return ret;
+  }
+  /* OQPSKC2 */
+  uint8_t reg_oqpskc2 =
+      ((conf->qpsk.spc & 0x01) << 5) | ((conf->qpsk.rpc & 0x01) << 4) |
+      ((conf->qpsk.enprop & 0x01) << 3) | ((conf->qpsk.fcstleg & 0x01) << 2) |
+      (conf->qpsk.rxm & 0x03);
+  ret = at86rf215_reg_write_8(h, reg_oqpskc2, REG_BBC0_OQPSKC2 + offset);
+  if (ret) {
+    return ret;
+  }
+  /* OQPSKC3 */
+  uint8_t reg_oqpskc3 =
+      ((conf->qpsk.hrleg & 0x01) << 5) | ((conf->qpsk.nsfd & 0x03) << 2);
+  ret = at86rf215_reg_write_8(h, reg_oqpskc3, REG_BBC0_OQPSKC3 + offset);
+  if (ret) {
+    return ret;
+  }
+  /* OQPSKPHRTX */
+  uint8_t reg_oqpskphrtx =
+      ((conf->qpsk.ppdut & 0x01) << 5) | ((conf->qpsk.rb0 & 0x01) << 4) |
+      ((conf->qpsk.drate_mod & 0x07) << 1) | (conf->qpsk.leg & 0x01);
+  ret = at86rf215_reg_write_8(h, reg_oqpskphrtx, REG_BBC0_OQPSKPHRTX + offset);
+  if (ret) {
+    return ret;
+  }
+
+  /* Frontend configuration settings */
+  ret = set_txdfe(h, radio, txdfe_rcut, conf->qpsk.dm, txdfe_sr);
+  if (ret) {
+    return ret;
+  }
+  ret = set_rxdfe(h, radio, rxdfe_rcut, rxdfe_sr);
+  if (ret) {
+    return ret;
+  }
+  ret = at86rf215_set_bw(h, radio, 0, rxbwc_ifs, rxbwc_bw);
+  if (ret) {
+    return ret;
+  }
+  uint8_t reg_edd = ((edd_df & 0x3F) << 2) | (edd_dtb & 0x03);
+  ret             = at86rf215_reg_write_8(
+      h, reg_edd, radio == AT86RF215_RF09 ? REG_RF09_EDD : REG_RF24_EDD);
+  if (ret) {
+    return ret;
+  }
+  ret = at86rf215_set_txcutc(h, radio, txcutc_paramp, txcutc_lpfcut);
+  if (ret) {
+    return ret;
+  }
+  uint16_t agcc_reg = (radio == AT86RF215_RF09) ? REG_RF09_AGCC : REG_RF24_AGCC;
+  uint8_t  agcc_val = 0;
+  ret               = at86rf215_reg_read_8(h, &agcc_val, agcc_reg);
+  if (ret) {
+    return ret;
+  }
+  agcc_val &= ~((1 << 6) | (3 << 4) | (1 << 0));
+  agcc_val |=
+      ((agcc_agci & 0x01) << 6) | ((agcc_avgs & 0x03) << 4) | (agcc_en & 0x01);
+  ret = at86rf215_reg_write_8(h, agcc_val, agcc_reg);
+  if (ret) {
+    return ret;
+  }
+  ret = at86rf215_set_agc_target(h, radio, agcs_tgt);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -2039,44 +2453,50 @@ static int bb_conf_mrfsk(struct at86rf215 *h, at86rf215_radio_t radio, const str
  * @param conf the condiguration of the baseband core
  * @return 0 on success or negative error code
  */
-int at86rf215_bb_conf(struct at86rf215 *h, at86rf215_radio_t radio, const struct at86rf215_bb_conf *conf) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!conf) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-    uint8_t val = conf->pt | (conf->fcst << 3) | (conf->txafcs << 4) | (conf->fcsfe << 6) | (conf->ctx << 3);
+int
+at86rf215_bb_conf(struct at86rf215 *h, at86rf215_radio_t radio,
+                  const struct at86rf215_bb_conf *conf)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!conf) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint8_t val = conf->pt | (conf->fcst << 3) | (conf->txafcs << 4) |
+                (conf->fcsfe << 6) | (conf->ctx << 3);
 
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_BBC0_PC;
-    } else {
-        reg = REG_BBC1_PC;
-    }
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_BBC0_PC;
+  } else {
+    reg = REG_BBC1_PC;
+  }
+  ret = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
 
-    switch (conf->pt) {
-        case AT86RF215_BB_MRFSK:
-            ret = bb_conf_mrfsk(h, radio, conf);
-            break;
-        case AT86RF215_BB_MROFDM:
-        case AT86RF215_BB_MROQPSK:
-        case AT86RF215_BB_PHYOFF:
-            return -AT86RF215_NOT_IMPL;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    if (ret) {
-        return ret;
-    }
-    /* Copy internally the configuration */
-    memcpy(&h->priv.bbc[radio], conf, sizeof(struct at86rf215_bb_conf));
-    return AT86RF215_OK;
+  switch (conf->pt) {
+  case AT86RF215_BB_MRFSK:
+    ret = bb_conf_mrfsk(h, radio, conf);
+    break;
+  case AT86RF215_BB_MROQPSK:
+    ret = bb_conf_mroqpsk(h, radio, conf);
+    break;
+  case AT86RF215_BB_MROFDM:
+  case AT86RF215_BB_PHYOFF:
+    return -AT86RF215_NOT_IMPL;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  if (ret) {
+    return ret;
+  }
+  /* Copy internally the configuration */
+  memcpy(&h->priv.bbc[radio], conf, sizeof(struct at86rf215_bb_conf));
+  return AT86RF215_OK;
 }
 
 /**
@@ -2086,24 +2506,27 @@ int at86rf215_bb_conf(struct at86rf215 *h, at86rf215_radio_t radio, const struct
  * @param en 1 to enable, 0 to disable
  * @return 0 on success or negative error code
  */
-int at86rf215_bb_enable(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t en) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    const struct at86rf215_bb_conf *conf = &h->priv.bbc[radio];
-    uint8_t val = conf->pt | ((en & 0x1) << 2) | (conf->fcst << 3) | (conf->txafcs << 4) | (conf->fcsfe << 6) | (conf->ctx << 3);
-    uint16_t reg = 0;
-    if (radio == AT86RF215_RF09) {
-        reg = REG_BBC0_PC;
-    } else {
-        reg = REG_BBC1_PC;
-    }
-    ret = at86rf215_reg_write_8(h, val, reg);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+int
+at86rf215_bb_enable(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t en)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  const struct at86rf215_bb_conf *conf = &h->priv.bbc[radio];
+  uint8_t  val = conf->pt | ((en & 0x1) << 2) | (conf->fcst << 3) |
+                 (conf->txafcs << 4) | (conf->fcsfe << 6) | (conf->ctx << 3);
+  uint16_t reg = 0;
+  if (radio == AT86RF215_RF09) {
+    reg = REG_BBC0_PC;
+  } else {
+    reg = REG_BBC1_PC;
+  }
+  ret = at86rf215_reg_write_8(h, val, reg);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -2114,71 +2537,74 @@ int at86rf215_bb_enable(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t en
  * @param len the size of the PSDU
  * @return 0 on success or negative error code
  */
-static int write_tx_buffer(struct at86rf215 *h, at86rf215_radio_t radio, const uint8_t *b, size_t len) {
-    int ret = 0;
-    if (radio == AT86RF215_RF09) {
-        /* Declare the size of the PSDU */
-        ret = at86rf215_reg_write_8(h, len & 0xFF, REG_BBC0_TXFLL);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, (len >> 8) & 0xFF, REG_BBC0_TXFLH);
-        if (ret) {
-            return ret;
-        }
-
-        /* Fill the buffer */
-        ret = at86rf215_set_seln(h, 0);
-        if (ret) {
-            return ret;
-        }
-        at86rf215_irq_enable(h, 0);
-        uint8_t mosi[2] = {(REG_BBC0_FBTXS >> 8) | 0x80, REG_BBC0_FBTXS & 0xFF};
-        ret = at86rf215_spi_write(h, mosi, 2);
-        if (ret) {
-            at86rf215_set_seln(h, 1);
-            at86rf215_irq_enable(h, 1);
-            return ret;
-        }
-        ret = at86rf215_spi_write(h, b, len);
-        if (ret) {
-            at86rf215_set_seln(h, 1);
-            at86rf215_irq_enable(h, 1);
-            return ret;
-        }
-    } else {
-        /* Declare the size of the PSDU */
-        ret = at86rf215_reg_write_8(h, len & 0xFF, REG_BBC1_TXFLL);
-        if (ret) {
-            return ret;
-        }
-        ret = at86rf215_reg_write_8(h, (len >> 8) & 0xFF, REG_BBC1_TXFLH);
-        if (ret) {
-            return ret;
-        }
-
-        /* Fill the buffer */
-        ret = at86rf215_set_seln(h, 0);
-        if (ret) {
-            return ret;
-        }
-        at86rf215_irq_enable(h, 0);
-        uint8_t mosi[2] = {(REG_BBC1_FBTXS >> 8) | 0x80, REG_BBC1_FBTXS & 0xFF};
-        ret = at86rf215_spi_write(h, mosi, 2);
-        if (ret) {
-            at86rf215_set_seln(h, 1);
-            at86rf215_irq_enable(h, 1);
-            return ret;
-        }
-        ret = at86rf215_spi_write(h, b, len);
-        if (ret) {
-            at86rf215_set_seln(h, 1);
-            at86rf215_irq_enable(h, 1);
-            return ret;
-        }
+static int
+write_tx_buffer(struct at86rf215 *h, at86rf215_radio_t radio, const uint8_t *b,
+                size_t len)
+{
+  int ret = 0;
+  if (radio == AT86RF215_RF09) {
+    /* Declare the size of the PSDU */
+    ret = at86rf215_reg_write_8(h, len & 0xFF, REG_BBC0_TXFLL);
+    if (ret) {
+      return ret;
     }
-    at86rf215_irq_enable(h, 1);
-    return at86rf215_set_seln(h, 1);
+    ret = at86rf215_reg_write_8(h, (len >> 8) & 0xFF, REG_BBC0_TXFLH);
+    if (ret) {
+      return ret;
+    }
+
+    /* Fill the buffer */
+    ret = at86rf215_set_seln(h, 0);
+    if (ret) {
+      return ret;
+    }
+    at86rf215_irq_enable(h, 0);
+    uint8_t mosi[2] = {(REG_BBC0_FBTXS >> 8) | 0x80, REG_BBC0_FBTXS & 0xFF};
+    ret             = at86rf215_spi_write(h, mosi, 2);
+    if (ret) {
+      at86rf215_set_seln(h, 1);
+      at86rf215_irq_enable(h, 1);
+      return ret;
+    }
+    ret = at86rf215_spi_write(h, b, len);
+    if (ret) {
+      at86rf215_set_seln(h, 1);
+      at86rf215_irq_enable(h, 1);
+      return ret;
+    }
+  } else {
+    /* Declare the size of the PSDU */
+    ret = at86rf215_reg_write_8(h, len & 0xFF, REG_BBC1_TXFLL);
+    if (ret) {
+      return ret;
+    }
+    ret = at86rf215_reg_write_8(h, (len >> 8) & 0xFF, REG_BBC1_TXFLH);
+    if (ret) {
+      return ret;
+    }
+
+    /* Fill the buffer */
+    ret = at86rf215_set_seln(h, 0);
+    if (ret) {
+      return ret;
+    }
+    at86rf215_irq_enable(h, 0);
+    uint8_t mosi[2] = {(REG_BBC1_FBTXS >> 8) | 0x80, REG_BBC1_FBTXS & 0xFF};
+    ret             = at86rf215_spi_write(h, mosi, 2);
+    if (ret) {
+      at86rf215_set_seln(h, 1);
+      at86rf215_irq_enable(h, 1);
+      return ret;
+    }
+    ret = at86rf215_spi_write(h, b, len);
+    if (ret) {
+      at86rf215_set_seln(h, 1);
+      at86rf215_irq_enable(h, 1);
+      return ret;
+    }
+  }
+  at86rf215_irq_enable(h, 1);
+  return at86rf215_set_seln(h, 1);
 }
 
 /**
@@ -2193,28 +2619,32 @@ static int write_tx_buffer(struct at86rf215 *h, at86rf215_radio_t radio, const u
  * @param len the number of bytes to read from the frame buffer
  * @return 0 on success or negative error code
  */
-int at86rf215_rx_frame(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t *psdu, size_t len) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!psdu) {
-        return -AT86RF215_INVAL_PARAM;
-    }
-
-    ret = at86rf215_set_seln(h, 0);
-    if (ret) {
-        return ret;
-    }
-    at86rf215_irq_enable(h, 0);
-    /* Construct properly the MOSI buffer */
-    const uint16_t reg = radio == AT86RF215_RF09 ? REG_BBC0_FBRXS : REG_BBC1_FBRXS;
-    uint8_t mosi[2] = {(reg >> 8) & 0x3F, reg & 0xFF};
-    ret = at86rf215_spi_read(h, spi_buffer, mosi, 2, len + 2);
-    at86rf215_irq_enable(h, 1);
-    at86rf215_set_seln(h, 1);
-    memcpy(psdu, spi_buffer + 2, len);
+int
+at86rf215_rx_frame(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t *psdu,
+                   size_t len)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
     return ret;
+  }
+  if (!psdu) {
+    return -AT86RF215_INVAL_PARAM;
+  }
+
+  ret = at86rf215_set_seln(h, 0);
+  if (ret) {
+    return ret;
+  }
+  at86rf215_irq_enable(h, 0);
+  /* Construct properly the MOSI buffer */
+  const uint16_t reg =
+      radio == AT86RF215_RF09 ? REG_BBC0_FBRXS : REG_BBC1_FBRXS;
+  uint8_t mosi[2] = {(reg >> 8) & 0x3F, reg & 0xFF};
+  ret             = at86rf215_spi_read(h, spi_buffer, mosi, 2, len + 2);
+  at86rf215_irq_enable(h, 1);
+  at86rf215_set_seln(h, 1);
+  memcpy(psdu, spi_buffer + 2, len);
+  return ret;
 }
 
 /**
@@ -2227,68 +2657,71 @@ int at86rf215_rx_frame(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t *ps
  * @param len the number of bytes to send
  * @return 0 on success or negative error code
  */
-int at86rf215_tx_frame(struct at86rf215 *h, at86rf215_radio_t radio, const uint8_t *psdu, size_t len, size_t timeout_ms) {
-    size_t deadline = at86rf215_get_time_ms(h) + timeout_ms;
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!psdu) {
-        return -AT86RF215_INVAL_PARAM;
-    }
+int
+at86rf215_tx_frame(struct at86rf215 *h, at86rf215_radio_t radio,
+                   const uint8_t *psdu, size_t len, size_t timeout_ms)
+{
+  size_t deadline = at86rf215_get_time_ms(h) + timeout_ms;
+  int    ret      = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!psdu) {
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    /*
-     * In order to transmit the frame, the corresponding baseband core should
-     * be enabled
-     */
-    if (h->priv.chpm == AT86RF215_RF_MODE_RF) {
-        return -AT86RF215_INVAL_CHPM;
+  /*
+   * In order to transmit the frame, the corresponding baseband core should
+   * be enabled
+   */
+  if (h->priv.chpm == AT86RF215_RF_MODE_RF) {
+    return -AT86RF215_INVAL_CHPM;
+  }
+  if (radio == AT86RF215_RF09) {
+    if (h->priv.chpm == AT86RF215_RF_MODE_BBRF09) {
+      return -AT86RF215_INVAL_CHPM;
     }
-    if (radio == AT86RF215_RF09) {
-        if (h->priv.chpm == AT86RF215_RF_MODE_BBRF09) {
-            return -AT86RF215_INVAL_CHPM;
-        }
-    } else {
-        if (h->priv.chpm == AT86RF215_RF_MODE_BBRF24) {
-            return -AT86RF215_INVAL_CHPM;
-        }
+  } else {
+    if (h->priv.chpm == AT86RF215_RF_MODE_BBRF24) {
+      return -AT86RF215_INVAL_CHPM;
     }
+  }
 
-    /*
-     * Write at least once the TXPREP so we are sure that we can start the
-     * transmission
-     */
-    at86rf215_rf_state_t state = AT86RF215_STATE_RF_TRANSITION;
-    while (state != AT86RF215_STATE_RF_TXPREP) {
-        if (at86rf215_get_time_ms(h) > deadline) {
-            return -AT86RF215_TIMEOUT;
-        }
-        at86rf215_set_cmd(h, AT86RF215_CMD_RF_TXPREP, radio);
-        at86rf215_delay_us(h, 100);
-        at86rf215_get_state(h, &state, radio);
+  /*
+   * Write at least once the TXPREP so we are sure that we can start the
+   * transmission
+   */
+  at86rf215_rf_state_t state = AT86RF215_STATE_RF_TRANSITION;
+  while (state != AT86RF215_STATE_RF_TXPREP) {
+    if (at86rf215_get_time_ms(h) > deadline) {
+      return -AT86RF215_TIMEOUT;
     }
+    at86rf215_set_cmd(h, AT86RF215_CMD_RF_TXPREP, radio);
+    at86rf215_delay_us(h, 100);
+    at86rf215_get_state(h, &state, radio);
+  }
 
-    ret = write_tx_buffer(h, radio, psdu, len);
-    if (ret) {
-        return ret;
-    }
+  ret = write_tx_buffer(h, radio, psdu, len);
+  if (ret) {
+    return ret;
+  }
 
-    struct at86rf215_radio *r = &h->priv.radios[radio];
-    r->tx_complete = 0;
+  struct at86rf215_radio *r = &h->priv.radios[radio];
+  r->tx_complete            = 0;
 
-    /* Data are on the buffer. Issue the TX cmd to send them */
-    ret = at86rf215_set_cmd(h, AT86RF215_CMD_RF_TX, radio);
-    if (ret) {
-        return ret;
+  /* Data are on the buffer. Issue the TX cmd to send them */
+  ret = at86rf215_set_cmd(h, AT86RF215_CMD_RF_TX, radio);
+  if (ret) {
+    return ret;
+  }
+  /* Wait for the transfer to complete */
+  while (r->tx_complete == 0) {
+    if (at86rf215_get_time_ms(h) > deadline) {
+      return -AT86RF215_TIMEOUT;
     }
-    /* Wait for the transfer to complete */
-    while (r->tx_complete == 0) {
-        if (at86rf215_get_time_ms(h) > deadline) {
-            return -AT86RF215_TIMEOUT;
-        }
-        at86rf215_delay_us(h, 100);
-    }
-    return AT86RF215_OK;
+    at86rf215_delay_us(h, 100);
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -2299,64 +2732,67 @@ int at86rf215_tx_frame(struct at86rf215 *h, at86rf215_radio_t radio, const uint8
  * @param timeout_ms timeout in milisceconds
  * @return 0 on success or negative error code
  */
-int at86rf215_rx(struct at86rf215 *h, at86rf215_radio_t radio, size_t timeout_ms) {
-    size_t deadline = at86rf215_get_time_ms(h) + timeout_ms;
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
+int
+at86rf215_rx(struct at86rf215 *h, at86rf215_radio_t radio, size_t timeout_ms)
+{
+  size_t deadline = at86rf215_get_time_ms(h) + timeout_ms;
+  int    ret      = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+
+  /*
+   * In order to transmit the frame, the corresponding baseband core should
+   * be enabled
+   */
+  if (h->priv.chpm == AT86RF215_RF_MODE_RF) {
+    return -AT86RF215_INVAL_CHPM;
+  }
+  if (radio == AT86RF215_RF09) {
+    if (h->priv.chpm == AT86RF215_RF_MODE_BBRF09) {
+      return -AT86RF215_INVAL_CHPM;
+    }
+  } else {
+    if (h->priv.chpm == AT86RF215_RF_MODE_BBRF24) {
+      return -AT86RF215_INVAL_CHPM;
+    }
+  }
+
+  at86rf215_rf_state_t state;
+  ret = at86rf215_get_state(h, &state, radio);
+  if (ret) {
+    return ret;
+  }
+
+  while (state != AT86RF215_STATE_RF_TRXOFF &&
+         state != AT86RF215_STATE_RF_TXPREP) {
+    at86rf215_delay_us(h, 100);
+    if (at86rf215_get_time_ms(h) > deadline) {
+      return -AT86RF215_TIMEOUT;
     }
 
     /*
-     * In order to transmit the frame, the corresponding baseband core should
-     * be enabled
+     * If the radio was in the TRXOFF state request again the TXPREP state
      */
-    if (h->priv.chpm == AT86RF215_RF_MODE_RF) {
-        return -AT86RF215_INVAL_CHPM;
+    if (state == AT86RF215_STATE_RF_TRXOFF) {
+      at86rf215_set_cmd(h, AT86RF215_CMD_RF_TXPREP, radio);
+      at86rf215_delay_us(h, 100);
     }
-    if (radio == AT86RF215_RF09) {
-        if (h->priv.chpm == AT86RF215_RF_MODE_BBRF09) {
-            return -AT86RF215_INVAL_CHPM;
-        }
-    } else {
-        if (h->priv.chpm == AT86RF215_RF_MODE_BBRF24) {
-            return -AT86RF215_INVAL_CHPM;
-        }
+    at86rf215_get_state(h, &state, radio);
+  }
+
+  at86rf215_delay_us(h, 100);
+
+  /* Go to RX state*/
+  while (state != AT86RF215_STATE_RF_RX) {
+    if (at86rf215_get_time_ms(h) > deadline) {
+      return -AT86RF215_TIMEOUT;
     }
-
-    at86rf215_rf_state_t state;
-    ret = at86rf215_get_state(h, &state, radio);
-    if (ret) {
-        return ret;
-    }
-
-    while (state != AT86RF215_STATE_RF_TRXOFF && state != AT86RF215_STATE_RF_TXPREP) {
-        at86rf215_delay_us(h, 100);
-        if (at86rf215_get_time_ms(h) > deadline) {
-            return -AT86RF215_TIMEOUT;
-        }
-
-        /*
-         * If the radio was in the TRXOFF state request again the TXPREP state
-         */
-        if (state == AT86RF215_STATE_RF_TRXOFF) {
-            at86rf215_set_cmd(h, AT86RF215_CMD_RF_TXPREP, radio);
-            at86rf215_delay_us(h, 100);
-        }
-        at86rf215_get_state(h, &state, radio);
-    }
-
+    at86rf215_set_cmd(h, AT86RF215_CMD_RF_RX, radio);
     at86rf215_delay_us(h, 100);
-
-    /* Go to RX state*/
-    while (state != AT86RF215_STATE_RF_RX) {
-        if (at86rf215_get_time_ms(h) > deadline) {
-            return -AT86RF215_TIMEOUT;
-        }
-        at86rf215_set_cmd(h, AT86RF215_CMD_RF_RX, radio);
-        at86rf215_delay_us(h, 100);
-        at86rf215_get_state(h, &state, radio);
-    }
-    return AT86RF215_OK;
+    at86rf215_get_state(h, &state, radio);
+  }
+  return AT86RF215_OK;
 }
 
 /**
@@ -2370,61 +2806,65 @@ int at86rf215_rx(struct at86rf215 *h, at86rf215_radio_t radio, size_t timeout_ms
  * @param conf IQ configration
  * @return 0 on success or negative error code
  */
-int at86rf215_iq_conf(struct at86rf215 *h, at86rf215_radio_t radio, const struct at86rf215_iq_conf *conf) {
-    int ret = supports_rf(h, radio);
-    if (ret) {
-        return ret;
-    }
-    if (!conf) {
-        return -AT86RF215_INVAL_PARAM;
-    }
+int
+at86rf215_iq_conf(struct at86rf215 *h, at86rf215_radio_t radio,
+                  const struct at86rf215_iq_conf *conf)
+{
+  int ret = supports_rf(h, radio);
+  if (ret) {
+    return ret;
+  }
+  if (!conf) {
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    switch (conf->drv) {
-        case AT86RF215_LVDS_DRV1:
-        case AT86RF215_LVDS_DRV2:
-        case AT86RF215_LVDS_DRV3:
-        case AT86RF215_LVDS_DRV4:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
+  switch (conf->drv) {
+  case AT86RF215_LVDS_DRV1:
+  case AT86RF215_LVDS_DRV2:
+  case AT86RF215_LVDS_DRV3:
+  case AT86RF215_LVDS_DRV4:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
 
-    switch (conf->cmv) {
-        case AT86RF215_LVDS_CMV150:
-        case AT86RF215_LVDS_CMV200:
-        case AT86RF215_LVDS_CMV250:
-        case AT86RF215_LVDS_CMV300:
-            break;
-        default:
-            return -AT86RF215_INVAL_PARAM;
-    }
-    uint8_t val = conf->eec | (conf->cmv1v2 << 1) | (conf->cmv << 2) | (conf->drv << 4) | (conf->extlb << 7);
-    ret = at86rf215_reg_write_8(h, val, REG_RF_IQIFC0);
-    if (ret) {
-        return ret;
-    }
-    /* Set the RF_IQIFC1 but leave the CHPM unchanged  */
-    ret = at86rf215_reg_read_8(h, &val, REG_RF_IQIFC1);
-    if (ret) {
-        return ret;
-    }
-    val &= BIT(4) | BIT(5) | BIT(6);
-    val |= conf->skedrv;
-    ret = at86rf215_reg_write_8(h, val, REG_RF_IQIFC1);
-    if (ret) {
-        return ret;
-    }
+  switch (conf->cmv) {
+  case AT86RF215_LVDS_CMV150:
+  case AT86RF215_LVDS_CMV200:
+  case AT86RF215_LVDS_CMV250:
+  case AT86RF215_LVDS_CMV300:
+    break;
+  default:
+    return -AT86RF215_INVAL_PARAM;
+  }
+  uint8_t val = conf->eec | (conf->cmv1v2 << 1) | (conf->cmv << 2) |
+                (conf->drv << 4) | (conf->extlb << 7);
+  ret         = at86rf215_reg_write_8(h, val, REG_RF_IQIFC0);
+  if (ret) {
+    return ret;
+  }
+  /* Set the RF_IQIFC1 but leave the CHPM unchanged  */
+  ret = at86rf215_reg_read_8(h, &val, REG_RF_IQIFC1);
+  if (ret) {
+    return ret;
+  }
+  val &= BIT(4) | BIT(5) | BIT(6);
+  val |= conf->skedrv;
+  ret = at86rf215_reg_write_8(h, val, REG_RF_IQIFC1);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply the TX sampling rate settings */
-    ret = set_txdfe(h, radio, conf->trcut, 0, conf->tsr);
-    if (ret) {
-        return ret;
-    }
+  /* Apply the TX sampling rate settings */
+  ret = set_txdfe(h, radio, conf->trcut, 0, conf->tsr);
+  if (ret) {
+    return ret;
+  }
 
-    /* Apply the RX sampling rate settings */
-    ret = set_rxdfe(h, radio, conf->rrcut, conf->rsr);
-    if (ret) {
-        return ret;
-    }
-    return AT86RF215_OK;
+  /* Apply the RX sampling rate settings */
+  ret = set_rxdfe(h, radio, conf->rrcut, conf->rsr);
+  if (ret) {
+    return ret;
+  }
+  return AT86RF215_OK;
 }

--- a/src/drivers/at86rf215/at86rf215.c
+++ b/src/drivers/at86rf215/at86rf215.c
@@ -1516,7 +1516,7 @@ at86rf215_set_agc(struct at86rf215 *h, at86rf215_radio_t radio,
 
   uint8_t val = (cnf->input << 6) | (cnf->avgs << 4) | (cnf->reset << 3) |
                 (cnf->freeze << 1) | cnf->enable;
-  ret         = at86rf215_reg_write_8(h, val, reg);
+  ret = at86rf215_reg_write_8(h, val, reg);
   if (ret) {
     return ret;
   }
@@ -1723,7 +1723,7 @@ at86rf215_set_aux_settings(struct at86rf215 *h, at86rf215_radio_t radio,
 
   uint8_t val = (cnf->extlnabyp << 7) | (cnf->agcmap << 5) | (cnf->avext << 4) |
                 (cnf->aven << 3) | cnf->pavc;
-  ret         = at86rf215_reg_write_8(h, val, reg);
+  ret = at86rf215_reg_write_8(h, val, reg);
   if (ret) {
     return ret;
   }
@@ -2340,7 +2340,7 @@ bb_conf_mroqpsk(struct at86rf215 *h, at86rf215_radio_t radio,
     return -AT86RF215_INVAL_PARAM;
   }
 
-  /* DM only valid on 100k Chip/s or 200k Chip/s */
+  /* DM only valid on 100k Chip/s or 200k Chip/s, (6.12.2.2) */
   if (conf->qpsk.dm && conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_100 &&
       conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_200) {
     return -AT86RF215_INVAL_CONF;
@@ -2349,15 +2349,20 @@ bb_conf_mroqpsk(struct at86rf215 *h, at86rf215_radio_t radio,
   if (conf->qpsk.dm && h->priv.version < 3) {
     return -AT86RF215_NOT_SUPPORTED;
   }
-  /* RXM = BOTH only enabled on FCHIP >= 1000k Chip/s */
+  /* RXM = BOTH only enabled on FCHIP >= 1000k Chip/s, (6.12.2.3) */
   if (conf->qpsk.rxm == AT86RF215_MROQPSK_RXM_BOTH &&
       conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_1000 &&
       conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_2000) {
     return -AT86RF215_INVAL_CONF;
   }
-  /* Rate mode 4 only valid at 2000k chip/s */
-  if (conf->qpsk.drate_mod == AT86RF215_MROQPSK_DRATE_MOD_4 &&
-      conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_2000) {
+  /* Rate mode validity depends on chip rate, (Table 6-102) */
+  if ((conf->qpsk.drate_mod == AT86RF215_MROQPSK_DRATE_MOD_4 &&
+       conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_2000) ||
+      (conf->qpsk.drate_mod == AT86RF215_MROQPSK_DRATE_MOD_3 &&
+       conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_1000 &&
+       conf->qpsk.fchip != AT86RF215_MROQPSK_FCHIP_2000) ||
+      (conf->qpsk.drate_mod == AT86RF215_MROQPSK_DRATE_MOD_2 &&
+       conf->qpsk.fchip == AT86RF215_MROQPSK_FCHIP_100)) {
     return -AT86RF215_INVAL_CONF;
   }
 
@@ -2514,8 +2519,8 @@ at86rf215_bb_enable(struct at86rf215 *h, at86rf215_radio_t radio, uint8_t en)
     return ret;
   }
   const struct at86rf215_bb_conf *conf = &h->priv.bbc[radio];
-  uint8_t  val = conf->pt | ((en & 0x1) << 2) | (conf->fcst << 3) |
-                 (conf->txafcs << 4) | (conf->fcsfe << 6) | (conf->ctx << 3);
+  uint8_t val = conf->pt | ((en & 0x1) << 2) | (conf->fcst << 3) |
+                (conf->txafcs << 4) | (conf->fcsfe << 6) | (conf->ctx << 3);
   uint16_t reg = 0;
   if (radio == AT86RF215_RF09) {
     reg = REG_BBC0_PC;
@@ -2839,7 +2844,7 @@ at86rf215_iq_conf(struct at86rf215 *h, at86rf215_radio_t radio,
   }
   uint8_t val = conf->eec | (conf->cmv1v2 << 1) | (conf->cmv << 2) |
                 (conf->drv << 4) | (conf->extlb << 7);
-  ret         = at86rf215_reg_write_8(h, val, REG_RF_IQIFC0);
+  ret = at86rf215_reg_write_8(h, val, REG_RF_IQIFC0);
   if (ret) {
     return ret;
   }

--- a/src/drivers/at86rf215/at86rf215.h
+++ b/src/drivers/at86rf215/at86rf215.h
@@ -488,6 +488,7 @@ typedef enum
 
 /**
  * Configuration for the AT86RF215 running in MR-O-QPSK mode
+ *
  */
 struct at86rf215_mroqpsk_conf
 {
@@ -499,8 +500,8 @@ struct at86rf215_mroqpsk_conf
 
   // OQPSKC1
   uint8_t rxo : 1; //!< Set to 1 to enable receiver override, 0 to disable
-  uint8_t rxoleg
-      : 1; //!< Set to 1 to enable legacy receiver override, 0 to disable
+  uint8_t
+      rxoleg : 1; //!< Set to 1 to enable legacy receiver override, 0 to disable
   uint8_t pdt0 : 3; //!< Preamble detector sensitivity for MR-O-QPSK, lower
                     //!< values are higher
   uint8_t pdt1 : 3; //!< Preamble detector sensitivity for legacy O-QPSK, lower
@@ -520,10 +521,8 @@ struct at86rf215_mroqpsk_conf
   at86rf215_mroqpsk_nsfd_t nsfd;
 
   // OQPSKPHRTX
-  uint8_t ppdut : 1; //!< Reflects the PPDU type for the last received MR-O-QPSK
-                     //!< frame. 0 is type 1, 1 is type 2.
-  uint8_t rb0
-      : 1; //!< Reflects the content of the reserved PHR bit RB0 in last frame
+  uint8_t ppdut : 1; //!< TX PPDU type: 0 = MR-O-QPSK type 1, 1 = type 2
+  uint8_t rb0   : 1; //!< Reserved PHR bit RB0 to transmit
   at86rf215_mroqpsk_data_rate_mod_t
           drate_mod; //!< Data rate (fchip dependent, see datasheet)
   uint8_t leg : 1;   //!< 0: transmit MR-O-QPSK, 1: transmit legacy O-QPSK
@@ -627,10 +626,10 @@ struct at86rf215_mrfsk_conf
   uint16_t sfd1; //!< 16-bit SFD. Tranmitted after SFD0 if SFD32 is set
   uint8_t  sfd : 1;
   uint8_t  dw  : 1; //!< If set to 1, whitening of the PSDU is enabled
-  uint8_t  rb2
-      : 1; //!< Sets the content of the reserved FSK PHR bit 2 for transmit
-  uint8_t rb1
-      : 1; //!< Sets the content of the reserved FSK PHR bit 1 for transmit
+  uint8_t
+      rb2 : 1; //!< Sets the content of the reserved FSK PHR bit 2 for transmit
+  uint8_t
+      rb1 : 1; //!< Sets the content of the reserved FSK PHR bit 1 for transmit
   uint8_t  dm;
   uint8_t  preemphasis      : 1;
   uint32_t preemphasis_taps : 24;

--- a/src/drivers/at86rf215/at86rf215.h
+++ b/src/drivers/at86rf215/at86rf215.h
@@ -419,7 +419,7 @@ typedef enum
 } at86rf215_fsk_fecs_t;
 
 /**
- * MR-O-QPSK type
+ * MR-O-QPSK chip rate
  * Chip rate can be selected with sub-register OQPSKC0.FCHIP
  */
 typedef enum
@@ -430,10 +430,8 @@ typedef enum
   AT86RF215_MROQPSK_FCHIP_2000 = 3, //!< 2000k chips/s
 } at86rf215_mroqpsk_fchip_t;
 
-
-
 /**
- * MR-O-QPSK data rate modifier
+ * MR-O-QPSK rate mode
  * Data rate can be selected with sub-register OQPSKPHRRX.MOD
  *
  * Note that some data rates are undefined depending on the chip rate select

--- a/src/drivers/at86rf215/at86rf215.h
+++ b/src/drivers/at86rf215/at86rf215.h
@@ -419,6 +419,119 @@ typedef enum
 } at86rf215_fsk_fecs_t;
 
 /**
+ * MR-O-QPSK type
+ * Chip rate can be selected with sub-register OQPSKC0.FCHIP
+ */
+typedef enum
+{
+  AT86RF215_MROQPSK_FCHIP_100  = 0, //!< 100k chips/s
+  AT86RF215_MROQPSK_FCHIP_200  = 1, //!< 200k chips/s
+  AT86RF215_MROQPSK_FCHIP_1000 = 2, //!< 1000k chips/s
+  AT86RF215_MROQPSK_FCHIP_2000 = 3, //!< 2000k chips/s
+} at86rf215_mroqpsk_fchip_t;
+
+
+
+/**
+ * MR-O-QPSK data rate modifier
+ * Data rate can be selected with sub-register OQPSKPHRRX.MOD
+ *
+ * Note that some data rates are undefined depending on the chip rate select
+ * for MR-O-QPSK. Check against the AT86RF215 datasheet (pg. 125).
+ */
+typedef enum
+{
+  AT86RF215_MROQPSK_DRATE_MOD_0 = 0, //!< Lowest data rate; always defined
+  AT86RF215_MROQPSK_DRATE_MOD_1 = 1,
+  AT86RF215_MROQPSK_DRATE_MOD_2 = 2,
+  AT86RF215_MROQPSK_DRATE_MOD_3 = 3,
+  AT86RF215_MROQPSK_DRATE_MOD_4 = 4, //!< Highest data rate; may be undefined
+} at86rf215_mroqpsk_data_rate_mod_t;
+
+/**
+ * MR-O-QPSK mod type
+ * Modulation type can be selected with sub-register OQPSKC0.MOD
+ *
+ * Note that OQPSKC0.DM enables direct modulation on MR-O-QPSK mode
+ */
+typedef enum
+{
+  AT86RF215_MROQPSK_BB_RC08 =
+      0, //!< RC-0.8 shaping (raised cosine, roll-off = 0.8)
+  AT86RF215_MROQPSK_BB_RRC08 =
+      1, //!< RRC-0.8 shaping (root raised cosine, roll-off = 0.8)
+} at86rf215_mroqpsk_fshape_mod_t;
+
+/**
+ * Configures receive mode for QPSK
+ */
+typedef enum
+{
+  AT86RF215_MROQPSK_RXM_MROQPSK_ONLY =
+      0, //!< Listen for frames of MR-O-QPSK PHY only
+  AT86RF215_MROQPSK_RXM_LEGACY_ONLY =
+      1, //!< Listen for frames of legacy O-QPSK PHY only (if applicable)
+  AT86RF215_MROQPSK_RXM_BOTH = 2, //!< Listen for both, frames of MR-O-QPSK and
+                                  //!< legacy O-QPSK PHY (if applicable)
+  AT86RF215_MROQPSK_RXM_DISABLED = 3, //!< Disable detection for both PHYs
+} at86rf215_mroqpsk_rxm_t;
+
+/**
+ * Configures the search space of SFD words for MR-O-QPSK
+ */
+typedef enum
+{
+  AT86RF215_MROQPSK_NSFD_SFD1      = 0, //!< Search for SFD_1 only
+  AT86RF215_MROQPSK_NSFD_SFD1_SFD2 = 1, //!< Search for SFD_1 and SFD_2
+  AT86RF215_MROQPSK_NSFD_SFD1_SFD3 = 2, //!< Search for SFD_1 and SFD_3
+  AT86RF215_MROQPSK_NSFD_SFD1_SFD2_SFD3 =
+      3, //!< Search for SFD_1 and SFD_2 and SFD_3
+} at86rf215_mroqpsk_nsfd_t;
+
+/**
+ * Configuration for the AT86RF215 running in MR-O-QPSK mode
+ */
+struct at86rf215_mroqpsk_conf
+{
+  // OQPSKC0
+  at86rf215_mroqpsk_fchip_t fchip; //!< Chip frequency
+  at86rf215_mroqpsk_fshape_mod_t
+          fshape_mod; //!< Configures the impulse response of the shaping filter
+  uint8_t dm : 1;     //!< Set to 1 to enable direct modulation, 0 to disable
+
+  // OQPSKC1
+  uint8_t rxo : 1; //!< Set to 1 to enable receiver override, 0 to disable
+  uint8_t rxoleg
+      : 1; //!< Set to 1 to enable legacy receiver override, 0 to disable
+  uint8_t pdt0 : 3; //!< Preamble detector sensitivity for MR-O-QPSK, lower
+                    //!< values are higher
+  uint8_t pdt1 : 3; //!< Preamble detector sensitivity for legacy O-QPSK, lower
+                    //!< values are higher
+
+  // OQPSKC2
+  uint8_t spc     : 1; //!< 1 enables, 0 disables RX spurious compensation
+  uint8_t rpc     : 1; //!< 1 enables, 0 disables RX power saving
+  uint8_t enprop  : 1; //!< 1 enables, 0 disables proprietary modes.
+  uint8_t fcstleg : 1; //!< 1: FCS type for legacy is 16 bit, 0: FCS type for
+                       //!< legacy is 32 bit
+  at86rf215_mroqpsk_rxm_t rxm; //!< Controls receive mode
+
+  // OQPSKC3
+  uint8_t hrleg : 1; //!< 1 enables, 0 disables a proprietary high data rate
+                     //!< mode for legacy O-QPSK.
+  at86rf215_mroqpsk_nsfd_t nsfd;
+
+  // OQPSKPHRTX
+  uint8_t ppdut : 1; //!< Reflects the PPDU type for the last received MR-O-QPSK
+                     //!< frame. 0 is type 1, 1 is type 2.
+  uint8_t rb0
+      : 1; //!< Reflects the content of the reserved PHR bit RB0 in last frame
+  at86rf215_mroqpsk_data_rate_mod_t
+          drate_mod; //!< Data rate (fchip dependent, see datasheet)
+  uint8_t leg : 1;   //!< 0: transmit MR-O-QPSK, 1: transmit legacy O-QPSK
+};
+
+/**
  * SFD condifuration
  */
 typedef enum
@@ -516,10 +629,10 @@ struct at86rf215_mrfsk_conf
   uint16_t sfd1; //!< 16-bit SFD. Tranmitted after SFD0 if SFD32 is set
   uint8_t  sfd : 1;
   uint8_t  dw  : 1; //!< If set to 1, whitening of the PSDU is enabled
-  uint8_t
-      rb2 : 1; //!< Sets the content of the reserved FSK PHR bit 2 for transmit
-  uint8_t
-      rb1 : 1; //!< Sets the content of the reserved FSK PHR bit 1 for transmit
+  uint8_t  rb2
+      : 1; //!< Sets the content of the reserved FSK PHR bit 2 for transmit
+  uint8_t rb1
+      : 1; //!< Sets the content of the reserved FSK PHR bit 1 for transmit
   uint8_t  dm;
   uint8_t  preemphasis      : 1;
   uint32_t preemphasis_taps : 24;
@@ -535,7 +648,8 @@ struct at86rf215_bb_conf
   at86rf215_phy_t pt;
   union
   {
-    struct at86rf215_mrfsk_conf fsk;
+    struct at86rf215_mrfsk_conf   fsk;
+    struct at86rf215_mroqpsk_conf qpsk;
   };
 };
 


### PR DESCRIPTION
Implements MR-O-QPSK modulation/PHY setup and operation to the LibreSpace AT86RF215 driver. Hopefully will upstream into the official driver. Also introduces LibreSpace's formatting rules to the at86rf215 driver subdirectory so future changes will conform to their formatting requirements and hopefully also be upstreamable. All functions and enums are annotated with datasheet sources.

Apologies for the delay on PR-ing; have been sitting on it for some time.